### PR TITLE
Renamed ModelSystemStructure to Node.

### DIFF
--- a/src/XTMF2/ModelSystemConstruct/Link.cs
+++ b/src/XTMF2/ModelSystemConstruct/Link.cs
@@ -28,18 +28,18 @@ using XTMF2.ModelSystemConstruct;
 namespace XTMF2
 {
     /// <summary>
-    /// Defines a directional connection between two model system structures
+    /// Defines a directional connection between two nodes
     /// </summary>
     public abstract class Link : INotifyPropertyChanged
     {
-        public ModelSystemStructure Origin { get; internal set; }
-        public ModelSystemStructureHook OriginHook { get; internal set; }
+        public Node Origin { get; internal set; }
+        public NodeHook OriginHook { get; internal set; }
 
         public bool IsDisabled { get; private set; }
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public bool SetOrigin(ModelSystemSession session, ModelSystemStructure origin, ModelSystemStructureHook originHook, ref string error)
+        public bool SetOrigin(ModelSystemSession session, Node origin, NodeHook originHook, ref string error)
         {
             Origin = origin;
             OriginHook = originHook;
@@ -57,7 +57,7 @@ namespace XTMF2
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        internal abstract void Save(Dictionary<ModelSystemStructure, int> moduleDictionary, JsonTextWriter writer);
+        internal abstract void Save(Dictionary<Node, int> moduleDictionary, JsonTextWriter writer);
         
         private static bool FailWith(out Link link, ref string error, string message)
         {
@@ -66,14 +66,14 @@ namespace XTMF2
             return false;
         }
 
-        internal static bool Create(ModelSystemSession session, Dictionary<int, ModelSystemStructure> structures, JsonTextReader reader, out Link link, ref string error)
+        internal static bool Create(ModelSystemSession session, Dictionary<int, Node> nodes, JsonTextReader reader, out Link link, ref string error)
         {
             if(reader.TokenType != JsonToken.StartObject)
             {
                 return FailWith(out link, ref error, "Expected a start object when loading a link.");
             }
-            ModelSystemStructure origin = null, destination = null;
-            List<ModelSystemStructure> destinations = null;
+            Node origin = null, destination = null;
+            List<Node> destinations = null;
             string hookName = null;
             bool disabled = false;
             int listIndex = 0;
@@ -93,7 +93,7 @@ namespace XTMF2
                     case "Origin":
                         {
                             var index = (int)reader.ReadAsInt32();
-                            origin = structures[index];
+                            origin = nodes[index];
                         }
                         break;
                     case "Hook":
@@ -112,15 +112,15 @@ namespace XTMF2
                                 case JsonToken.Integer:
                                     {
                                         var index = (int)(long)reader.Value;
-                                        destination = structures[index];
+                                        destination = nodes[index];
                                     }
                                     break;
                                 case JsonToken.StartArray:
                                     {
-                                        destinations = new List<ModelSystemStructure>();
+                                        destinations = new List<Node>();
                                         while(reader.Read() && reader.TokenType != JsonToken.EndArray)
                                         {
-                                            destinations.Add(structures[(int)(long)reader.Value]);
+                                            destinations.Add(nodes[(int)(long)reader.Value]);
                                         }
                                     }
                                     break;

--- a/src/XTMF2/ModelSystemConstruct/ModelSystem.cs
+++ b/src/XTMF2/ModelSystemConstruct/ModelSystem.cs
@@ -144,8 +144,8 @@ namespace XTMF2
             int index = 0;
             writer.WritePropertyName("Boundaries");
             writer.WriteStartArray();
-            Dictionary<ModelSystemStructure, int> moduleDictionary = new Dictionary<ModelSystemStructure, int>();
-            GlobalBoundary.Save(ref index, moduleDictionary, typeDictionary, writer);
+            Dictionary<Node, int> nodeDictionary = new Dictionary<Node, int>();
+            GlobalBoundary.Save(ref index, nodeDictionary, typeDictionary, writer);
             writer.WriteEndArray();
         }
 
@@ -227,7 +227,7 @@ namespace XTMF2
                 using (var reader = new JsonTextReader(stream))
                 {
                     var typeLookup = new Dictionary<int, Type>();
-                    var structures = new Dictionary<int, ModelSystemStructure>();
+                    var nodes = new Dictionary<int, Node>();
                     while (reader.Read())
                     {
                         if (reader.TokenType == JsonToken.PropertyName)
@@ -241,7 +241,7 @@ namespace XTMF2
                                     }
                                     break;
                                 case "Boundaries":
-                                    if (!LoadBoundaries(session, typeLookup, structures, reader, modelSystem.GlobalBoundary, ref error))
+                                    if (!LoadBoundaries(session, typeLookup, nodes, reader, modelSystem.GlobalBoundary, ref error))
                                     {
                                         return null;
                                     }
@@ -327,14 +327,14 @@ namespace XTMF2
             return true;
         }
 
-        private static bool LoadBoundaries(ModelSystemSession session, Dictionary<int, Type> typeLookup, Dictionary<int, ModelSystemStructure> structures,
+        private static bool LoadBoundaries(ModelSystemSession session, Dictionary<int, Type> typeLookup, Dictionary<int, Node> nodes,
             JsonTextReader reader, Boundary global, ref string error)
         {
             if (!reader.Read() || reader.TokenType != JsonToken.StartArray)
             {
                 return FailWith(ref error, "Expected to read an array when loading boundaries!");
             }
-            if (!global.Load(session, typeLookup, structures, reader, ref error))
+            if (!global.Load(session, typeLookup, nodes, reader, ref error))
             {
                 return false;
             }

--- a/src/XTMF2/ModelSystemConstruct/MultiLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/MultiLink.cs
@@ -27,34 +27,34 @@ namespace XTMF2.ModelSystemConstruct
 {
     public sealed class MultiLink : Link
     {
-        private ObservableCollection<ModelSystemStructure> _Destinations;
+        private ObservableCollection<Node> _Destinations;
 
-        public MultiLink(List<ModelSystemStructure> destinations)
+        public MultiLink(List<Node> destinations)
         {
-            _Destinations = new ObservableCollection<ModelSystemStructure>(destinations);
+            _Destinations = new ObservableCollection<Node>(destinations);
         }
 
         public MultiLink()
         {
-            _Destinations = new ObservableCollection<ModelSystemStructure>();
+            _Destinations = new ObservableCollection<Node>();
         }
 
-        public ReadOnlyObservableCollection<ModelSystemStructure> Destinations =>
-            new ReadOnlyObservableCollection<ModelSystemStructure>(_Destinations);
+        public ReadOnlyObservableCollection<Node> Destinations =>
+            new ReadOnlyObservableCollection<Node>(_Destinations);
 
-        internal bool AddDestination(ModelSystemStructure destination, ref string error)
+        internal bool AddDestination(Node destination, ref string error)
         {
             _Destinations.Add(destination);
             return true;
         }
 
-        internal bool AddDestination(ModelSystemStructure destination, int index)
+        internal bool AddDestination(Node destination, int index)
         {
             _Destinations.Insert(index, destination);
             return true;
         }
 
-        internal override void Save(Dictionary<ModelSystemStructure, int> moduleDictionary, JsonTextWriter writer)
+        internal override void Save(Dictionary<Node, int> moduleDictionary, JsonTextWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("Origin");

--- a/src/XTMF2/ModelSystemConstruct/NodeHook.cs
+++ b/src/XTMF2/ModelSystemConstruct/NodeHook.cs
@@ -24,9 +24,9 @@ using System.Text;
 namespace XTMF2
 {
     /// <summary>
-    /// Defines the places to connect links between model system structures.
+    /// Defines the places to connect links between nodes.
     /// </summary>
-    public abstract class ModelSystemStructureHook
+    public abstract class NodeHook
     {
         public string Name { get; private set; }
 
@@ -34,7 +34,7 @@ namespace XTMF2
 
         public int Index { get; private set; }
 
-        public ModelSystemStructureHook(string name, HookCardinality cardinality, int index)
+        public NodeHook(string name, HookCardinality cardinality, int index)
         {
             Name = name;
             Cardinality = cardinality;
@@ -60,7 +60,7 @@ namespace XTMF2
         /// </summary>
         /// <param name="origin"></param>
         /// <param name="destination"></param>
-        internal abstract void Install(ModelSystemStructure origin, ModelSystemStructure destination, int index);
+        internal abstract void Install(Node origin, Node destination, int index);
 
         /// <summary>
         /// Create the array of data with the given size
@@ -79,9 +79,9 @@ namespace XTMF2
     }
 
     /// <summary>
-    /// A hook on the property of a model system structure
+    /// A hook on the property of a node
     /// </summary>
-    sealed class PropertyHook : ModelSystemStructureHook
+    sealed class PropertyHook : NodeHook
     {
         readonly PropertyInfo Property;
         public PropertyHook(string name, PropertyInfo property, bool required, int index)
@@ -92,7 +92,7 @@ namespace XTMF2
 
         private static HookCardinality GetCardinality(PropertyInfo property, bool required)
         {
-            return ModelSystemStructureHook.GetCardinality(property.PropertyType, required);
+            return NodeHook.GetCardinality(property.PropertyType, required);
         }
 
         internal override void CreateArray(IModule origin, int length)
@@ -100,7 +100,7 @@ namespace XTMF2
             Property.SetValue(origin, Array.CreateInstance(Property.PropertyType.GetElementType(), length));
         }
 
-        internal override void Install(ModelSystemStructure origin, ModelSystemStructure destination, int index)
+        internal override void Install(Node origin, Node destination, int index)
         {
             switch (Cardinality)
             {
@@ -125,9 +125,9 @@ namespace XTMF2
     }
 
     /// <summary>
-    /// A hook for the field of a model system structure
+    /// A hook for the field of a node
     /// </summary>
-    sealed class FieldHook : ModelSystemStructureHook
+    sealed class FieldHook : NodeHook
     {
         readonly FieldInfo Field;
         public FieldHook(string name, FieldInfo field, bool required, int index)
@@ -138,7 +138,7 @@ namespace XTMF2
 
         private static HookCardinality GetCardinality(FieldInfo field, bool required)
         {
-            return ModelSystemStructureHook.GetCardinality(field.FieldType, required);
+            return NodeHook.GetCardinality(field.FieldType, required);
         }
 
         internal override void CreateArray(IModule origin, int length)
@@ -146,7 +146,7 @@ namespace XTMF2
             Field.SetValue(origin, Array.CreateInstance(Field.FieldType.GetElementType(), length));
         }
 
-        internal override void Install(ModelSystemStructure origin, ModelSystemStructure destination, int index)
+        internal override void Install(Node origin, Node destination, int index)
         {
             switch (Cardinality)
             {

--- a/src/XTMF2/ModelSystemConstruct/SingleLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/SingleLink.cs
@@ -27,15 +27,15 @@ namespace XTMF2.ModelSystemConstruct
 {
     internal sealed class SingleLink : Link
     {
-        public ModelSystemStructure Destination { get; internal set; }
-        public bool SetDestination(ModelSystemSession session, ModelSystemStructure destination, ref string error)
+        public Node Destination { get; internal set; }
+        public bool SetDestination(ModelSystemSession session, Node destination, ref string error)
         {
             Destination = destination;
             Notify(nameof(Destination));
             return true;
         }
 
-        internal override void Save(Dictionary<ModelSystemStructure, int> moduleDictionary, JsonTextWriter writer)
+        internal override void Save(Dictionary<Node, int> moduleDictionary, JsonTextWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("Origin");

--- a/src/XTMF2/ModelSystemConstruct/Start.cs
+++ b/src/XTMF2/ModelSystemConstruct/Start.cs
@@ -26,11 +26,11 @@ using XTMF2.Editing;
 namespace XTMF2.ModelSystemConstruct
 {
     /// <summary>
-    /// A start is a special model system structure where
+    /// A start is a special node where
     /// it has no type and can be used to enter the
     /// model system
     /// </summary>
-    public sealed class Start : ModelSystemStructure
+    public sealed class Start : Node
     {
         public Start(ModelSystemSession session, string startName, Boundary boundary, string description, Point point) : base(startName)
         {
@@ -41,7 +41,7 @@ namespace XTMF2.ModelSystemConstruct
             SetType(session, typeof(StartModule), ref error);
         }
 
-        internal override void Save(ref int index, Dictionary<ModelSystemStructure, int> moduleDictionary, Dictionary<Type, int> typeDictionary, JsonTextWriter writer)
+        internal override void Save(ref int index, Dictionary<Node, int> moduleDictionary, Dictionary<Type, int> typeDictionary, JsonTextWriter writer)
         {
             moduleDictionary.Add(this, index);
             writer.WriteStartObject();
@@ -65,7 +65,7 @@ namespace XTMF2.ModelSystemConstruct
             return false;
         }
 
-        internal static bool Load(ModelSystemSession session, Dictionary<int, ModelSystemStructure> structures,
+        internal static bool Load(ModelSystemSession session, Dictionary<int, Node> nodes,
             Boundary boundary, JsonTextReader reader, out Start start, ref string error)
         {
             if (reader.TokenType != JsonToken.StartObject)
@@ -108,7 +108,7 @@ namespace XTMF2.ModelSystemConstruct
             {
                 return FailWith(out start, ref error, "Undefined name for a start in boundary " + boundary.FullPath);
             }
-            if (structures.ContainsKey(index))
+            if (nodes.ContainsKey(index))
             {
                 return FailWith(out start, ref error, $"Index {index} already exists!");
             }
@@ -116,7 +116,7 @@ namespace XTMF2.ModelSystemConstruct
             {
                 ContainedWithin = boundary
             };
-            structures.Add(index, start);
+            nodes.Add(index, start);
             return true;
         }
 

--- a/src/XTMF2/Repository/ModuleRepository.cs
+++ b/src/XTMF2/Repository/ModuleRepository.cs
@@ -30,8 +30,8 @@ namespace XTMF2.Repository
     /// </summary>
     public sealed class ModuleRepository
     {
-        private ConcurrentDictionary<Type, (ModuleAttribute Description, TypeInfo TypeInfo, ModelSystemStructureHook[] Hooks)> _Data
-            = new ConcurrentDictionary<Type, (ModuleAttribute Description, TypeInfo TypeInfo, ModelSystemStructureHook[] Hooks)>();
+        private ConcurrentDictionary<Type, (ModuleAttribute Description, TypeInfo TypeInfo, NodeHook[] Hooks)> _Data
+            = new ConcurrentDictionary<Type, (ModuleAttribute Description, TypeInfo TypeInfo, NodeHook[] Hooks)>();
         private static TypeInfo IModuleTypeInfo = typeof(IModule).GetTypeInfo();
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace XTMF2.Repository
         /// </summary>
         /// <param name="type">The type to get the information from.</param>
         /// <returns>The description, typeinfo, and hooks for the type.</returns>
-        public (ModuleAttribute Description, TypeInfo TypeInfo, ModelSystemStructureHook[] Hooks) this[Type type]
+        public (ModuleAttribute Description, TypeInfo TypeInfo, NodeHook[] Hooks) this[Type type]
         {
             get
             {
@@ -93,7 +93,7 @@ namespace XTMF2.Repository
             }
         }
 
-        private (ModuleAttribute Description, TypeInfo TypeInfo, ModelSystemStructureHook[] Hooks) GetTypeData(Type type)
+        private (ModuleAttribute Description, TypeInfo TypeInfo, NodeHook[] Hooks) GetTypeData(Type type)
         {
             if (type == null)
             {
@@ -101,7 +101,7 @@ namespace XTMF2.Repository
             }
 
             var typeInfo = type.GetTypeInfo();
-            var hooks = new List<ModelSystemStructureHook>();
+            var hooks = new List<NodeHook>();
             // Load properties and fields
             ModuleAttribute description = LoadModuleDescription(type);
             LoadFields(type, typeInfo, hooks);
@@ -156,7 +156,7 @@ namespace XTMF2.Repository
             return description;
         }
 
-        private static void LoadFields(Type type, TypeInfo typeInfo, List<ModelSystemStructureHook> hooks)
+        private static void LoadFields(Type type, TypeInfo typeInfo, List<NodeHook> hooks)
         {
             if (typeInfo == null)
             {
@@ -220,7 +220,7 @@ namespace XTMF2.Repository
             }
         }
 
-        private static void LoadProperties(Type type, TypeInfo typeInfo, List<ModelSystemStructureHook> hooks)
+        private static void LoadProperties(Type type, TypeInfo typeInfo, List<NodeHook> hooks)
         {
             if (typeInfo == null)
             {

--- a/src/XTMF2/RuntimeModules/StartModule.cs
+++ b/src/XTMF2/RuntimeModules/StartModule.cs
@@ -23,13 +23,13 @@ using System.Text;
 namespace XTMF2.RuntimeModules
 {
     /// <summary>
-    /// The type used for a model system structure start
+    /// The type used for a start node
     /// </summary>
     [Module(Name = "Start", DocumentationLink = "http://tmg.utoronto.ca/doc/2.0",
 Description = "A starting point for a model system.")]
     public sealed class StartModule : BaseAction
     {
-        [SubModule(Name = "ToExecute", Description = "The module to invoke when executing this start.", Index = 0)]
+        [SubModule(Name = "ToExecute", Description = "The node to invoke when executing this start.", Index = 0)]
         public IAction ToExecute;
 
         public override void Invoke()

--- a/tests/XTMF2.UnitTests/Editing/TestDisabledNode.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestDisabledNode.cs
@@ -33,25 +33,25 @@ using System.Threading;
 namespace TestXTMF.Editing
 {
     [TestClass]
-    public class TestDisabledModule
+    public class TestDisabledNode
     {
         [TestMethod]
-        public void TestDisablingModule()
+        public void TestDisablingNode()
         {
-            RunInModelSystemContext("ModelSystemSavedWithModelSystemStructureOnly", (user, pSession, mSession) =>
+            RunInModelSystemContext("TestDisablingNode", (user, pSession, mSession) =>
             {
                 // initialization
                 var ms = mSession.ModelSystem;
                 string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
                 Assert.AreEqual("MyMSS", mss.Name);
-                Assert.IsFalse(mss.IsDisabled, "The model system structure started out as disabled!");
-                Assert.IsTrue(mSession.SetModelSystemStructureDisabled(user, mss, true, ref error), error);
-                Assert.IsTrue(mss.IsDisabled, "The model system structure was not disabled!");
+                Assert.IsFalse(mss.IsDisabled, "The node started out as disabled!");
+                Assert.IsTrue(mSession.SetNodeDisabled(user, mss, true, ref error), error);
+                Assert.IsTrue(mss.IsDisabled, "The node was not disabled!");
                 Assert.IsTrue(mSession.Undo(ref error), error);
-                Assert.IsFalse(mss.IsDisabled, "The model system structure was not re-enabled when undoing the disable instruction!");
+                Assert.IsFalse(mss.IsDisabled, "The node was not re-enabled when undoing the disable instruction!");
                 Assert.IsTrue(mSession.Redo(ref error), error);
-                Assert.IsTrue(mss.IsDisabled, "The model system structure was not disabled during the redo!");
+                Assert.IsTrue(mss.IsDisabled, "The node was not disabled during the redo!");
             }, (user, pSession, mSession) =>
             {
                 // after shutdown
@@ -63,17 +63,17 @@ namespace TestXTMF.Editing
         }
 
         [TestMethod]
-        public void TestDisabledModuleRunValidationFailure()
+        public void TestDisabledNodeRunValidationFailure()
         {
-            RunInModelSystemContext("ParameterModules", (user, pSession, msSession) =>
+            RunInModelSystemContext("TestDisabledNodeRunValidationFailure", (user, pSession, msSession) =>
             {
                 string error2 = null;
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetModelSystemStructureDisabled(user, basicParameter, true, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
+                Assert.IsTrue(msSession.SetNodeDisabled(user, basicParameter, true, ref error2), error2);
                 Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, ref error2), error2);
@@ -109,15 +109,15 @@ namespace TestXTMF.Editing
         [TestMethod]
         public void TestDisableLink()
         {
-            RunInModelSystemContext("ModelSystemSavedWithModelSystemStructureOnly", (user, pSession, msSession) =>
+            RunInModelSystemContext("TestDisableLink", (user, pSession, msSession) =>
             {
                 // initialization
                 var ms = msSession.ModelSystem;
                 string error = null;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error), error);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error), error);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error), error);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error), error);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error), error);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error), error);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error), error);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var startLink, ref error), error);
 
                 Assert.IsFalse(startLink.IsDisabled, "The link initialized as disabled!");
@@ -147,9 +147,9 @@ namespace TestXTMF.Editing
                 string error2 = null;
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
                 Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var requiredLink, ref error2), error2);

--- a/tests/XTMF2.UnitTests/TestHelper.cs
+++ b/tests/XTMF2.UnitTests/TestHelper.cs
@@ -193,12 +193,12 @@ namespace TestXTMF
         }
 
         /// <summary>
-        /// Get a model systems structure with the given name.
+        /// Get a node hook with the given name.
         /// </summary>
         /// <param name="hooks">The stet of hooks available</param>
         /// <param name="name">The name of the hook to access</param>
         /// <returns>The hook with the given name, or null if it isn't found.</returns>
-        public static ModelSystemStructureHook GetHook(IReadOnlyList<ModelSystemStructureHook> hooks, string name)
+        public static NodeHook GetHook(IReadOnlyList<NodeHook> hooks, string name)
         {
             return hooks.FirstOrDefault(hook => hook.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }

--- a/tests/XTMF2.UnitTests/TestModelSystem.cs
+++ b/tests/XTMF2.UnitTests/TestModelSystem.cs
@@ -175,14 +175,14 @@ namespace TestXTMF
         }
 
         [TestMethod]
-        public void ModelSystemSavedWithModelSystemStructureOnly()
+        public void ModelSystemSavedWithNodeOnly()
         {
-            RunInModelSystemContext("ModelSystemSavedWithModelSystemStructureOnly", (user, pSession, mSession) =>
+            RunInModelSystemContext("ModelSystemSavedWithNodeOnly", (user, pSession, mSession) =>
             {
                 // initialization
                 var ms = mSession.ModelSystem;
                 string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
                 Assert.AreEqual("MyMSS", mss.Name);
             }, (user, pSession, mSession) =>
             {
@@ -193,14 +193,14 @@ namespace TestXTMF
         }
 
         [TestMethod]
-        public void ModelSystemSavedWithStartAndModelSystemStructure()
+        public void ModelSystemSavedWithStartAndNode()
         {
-            RunInModelSystemContext("ModelSystemSavedWithStartAndModelSystemStructure", (user, pSession, mSession) =>
+            RunInModelSystemContext("ModelSystemSavedWithStartAndNode", (user, pSession, mSession) =>
             {
                 // initialization
                 var ms = mSession.ModelSystem;
                 string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
                 Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
                 Assert.AreEqual("MyMSS", mss.Name);
             }, (user, pSession, mSession) =>
@@ -222,7 +222,7 @@ namespace TestXTMF
                 // initialization
                 var ms = mSession.ModelSystem;
                 string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
                 Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
                 Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss, out var link, ref error), error);
                 Assert.AreEqual("MyMSS", mss.Name);
@@ -248,11 +248,11 @@ namespace TestXTMF
                 string error = null;
                 Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
 
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
 
 
                 Assert.IsTrue(mSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, ref error), error);
@@ -330,14 +330,14 @@ namespace TestXTMF
         }
 
         [TestMethod]
-        public void UndoAddModelSystemStructure()
+        public void UndoAddNode()
         {
-            RunInModelSystemContext("UndoAddModelSystemStructure", (user, pSession, mSession) =>
+            RunInModelSystemContext("UndoAddNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
                 string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
                     out var mss, ref error), error);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.Undo(ref error), error);
@@ -349,14 +349,14 @@ namespace TestXTMF
         }
 
         [TestMethod]
-        public void UndoRemoveModelSystemStructure()
+        public void UndoRemoveNode()
         {
-            RunInModelSystemContext("UndoRemoveModelSystemStructure", (user, pSession, mSession) =>
+            RunInModelSystemContext("UndoRemoveNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
                 string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
                     out var mss, ref error), error);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.Undo(ref error), error);
@@ -365,8 +365,8 @@ namespace TestXTMF
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreSame(mss, ms.GlobalBoundary.Modules[0]);
 
-                // now remove model system structure explicitly
-                Assert.IsTrue(mSession.RemoveModelSystemStructure(user, mss, ref error), error);
+                // now remove node explicitly
+                Assert.IsTrue(mSession.RemoveNode(user, mss, ref error), error);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.Undo(ref error), error);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
@@ -382,9 +382,9 @@ namespace TestXTMF
                 var ms = mSession.ModelSystem;
                 string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
                     out var parameter, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
                     out var module, ref error), error);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
@@ -406,9 +406,9 @@ namespace TestXTMF
                 var ms = mSession.ModelSystem;
                 string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
                     out var parameter, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
                     out var module, ref error), error);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
@@ -444,8 +444,8 @@ namespace TestXTMF
                 var ms = mSession.ModelSystem;
                 string error = null;
                 Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss1, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss2, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss1, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss2, ref error));
                 Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss1, out var link1, ref error), error);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 // This should not create a new link but move the previous one
@@ -619,7 +619,7 @@ namespace TestXTMF
                 // Setup the delete
                 Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, ref error), error);
                 Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
+                Assert.IsTrue(mSession.AddNode(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
                     out var tricky, ref error), error);
                 Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], tricky, out var link, ref error), error);
                 Assert.AreEqual(1, global.Starts.Count);
@@ -647,9 +647,9 @@ namespace TestXTMF
                 // Setup the delete
                 Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, ref error), error);
                 Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, global, "Execute", typeof(Execute),
+                Assert.IsTrue(mSession.AddNode(user, global, "Execute", typeof(Execute),
                     out var execute, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
+                Assert.IsTrue(mSession.AddNode(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
                     out var tricky, ref error), error);
                 Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, ref error), error);
                 Assert.IsTrue(mSession.AddLink(user, execute, GetHook(execute.Hooks, "To Execute"), tricky, out var link2, ref error), error);
@@ -677,9 +677,9 @@ namespace TestXTMF
                 string error = null;
                 var global = ms.GlobalBoundary;
                 Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, global, "Execute", typeof(Execute),
+                Assert.IsTrue(mSession.AddNode(user, global, "Execute", typeof(Execute),
                     out var execute, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStructure(user, global, "Tricky", typeof(IgnoreResult<string>),
+                Assert.IsTrue(mSession.AddNode(user, global, "Tricky", typeof(IgnoreResult<string>),
                     out var ignore, ref error), error);
 
                 Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, ref error), error);

--- a/tests/XTMF2.UnitTests/TestRun.cs
+++ b/tests/XTMF2.UnitTests/TestRun.cs
@@ -68,8 +68,8 @@ namespace TestXTMF
                 string error2 = null;
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], stm, out var ignoreLink2, ref error2), error2);
                 CreateRunClient(true, (runBus) =>
@@ -108,9 +108,9 @@ namespace TestXTMF
                 string error2 = null;
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
                 Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, ref error2), error2);
@@ -152,11 +152,11 @@ namespace TestXTMF
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
 
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, ref error));
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, ref error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
 
 
                 Assert.IsTrue(msSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, ref error), error);
@@ -207,10 +207,10 @@ namespace TestXTMF
                 string error2 = null;
                 var ms = msSession.ModelSystem;
                 Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "AnIgnore", typeof(ReportFunctionInvocation<string>), out var report, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "Message", typeof(BasicParameter<string>), out var message, ref error2), error2);
-                Assert.IsTrue(msSession.AddModelSystemStructure(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(ReportFunctionInvocation<string>), out var report, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Message", typeof(BasicParameter<string>), out var message, ref error2), error2);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], report, out var ignoreLink2, ref error2), error2);
                 Assert.IsTrue(msSession.AddLink(user, report, GetHook(report.Hooks, "To Invoke"), stm, out var ignoreLink3, ref error2), error2);


### PR DESCRIPTION
Renamed ModelSystemStructureHook to NodeHook.
Updated all strings containing model system structure to refer to node.
Issue #27