### PR TITLE
Import model system

### DIFF
--- a/src/XTMF2/Editing/ProjectSession.cs
+++ b/src/XTMF2/Editing/ProjectSession.cs
@@ -516,5 +516,24 @@ namespace XTMF2.Editing
                 return Project.RemoveAdditionalUser(toRestrict, ref error);
             }
         }
+
+        public bool ImportModelSystem(User user, string fullName, string modelSystemName, out ModelSystemHeader header)
+        {
+            if (user is null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            if (string.IsNullOrWhiteSpace(fullName))
+            {
+                throw new ArgumentException(nameof(fullName));
+            }
+
+            if (string.IsNullOrWhiteSpace(modelSystemName))
+            {
+                throw new ArgumentException(nameof(modelSystemName));
+            }
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/XTMF2/Editing/ProjectSession.cs
+++ b/src/XTMF2/Editing/ProjectSession.cs
@@ -250,47 +250,6 @@ namespace XTMF2.Editing
         }
 
         /// <summary>
-        /// Constant strings used for importing and exporting
-        /// a model system.
-        /// </summary>
-        private static class ModelSystemFileStrings
-        {
-            /// <summary>
-            /// A string used for the meta-data to gather the name of the model system.
-            /// </summary>
-            internal const string Name = "Name";
-            /// <summary>
-            /// A string used in the meta-data to provide a description of the model system.
-            /// </summary>
-            internal const string Description = "Description";
-            /// <summary>
-            /// A string used in the meta-data to give the name of the user that exported the model system
-            /// </summary>
-            internal const string ExportedBy = "ExportedBy";
-            /// <summary>
-            /// A string used by the meta-data to give what time in UTC that the model system was exported at.
-            /// </summary>
-            internal const string ExportedOn = "ExportedOn";
-            /// <summary>
-            /// A string used by the meta-data to indicate what version of XTMF exported the model system.
-            /// </summary>
-            internal const string VersionMajor = "VersionMajor";
-            /// <summary>
-            /// A string used by the meta-data to indicate what version of XTMF exported the model system.
-            /// </summary>
-            internal const string VersionMinor = "VersionMinor";
-
-            /// <summary>
-            /// The name of the file within the archive for where the model system was stored.
-            /// </summary>
-            internal const string ModelSystemFile = "ModelSystem.xmsys";
-            /// <summary>
-            /// The name of the file within the archive for where the meta-data was stored.
-            /// </summary>
-            internal const string MetaDataFile = "metadata.json";
-        }
-
-        /// <summary>
         /// Exports a model system to file.
         /// </summary>
         /// <param name="user">The user that is issuing the command.</param>
@@ -315,75 +274,20 @@ namespace XTMF2.Editing
                 error = "The path to save the model system to must not be empty.";
                 return false;
             }
-            var tempDirName = Path.Combine(Path.GetTempPath(), "XTMF-" + Project.Name + modelSystemHeader.Name + Guid.NewGuid());
-            System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
-            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
-            try
+            lock (_sessionLock)
             {
-                lock (_sessionLock)
+                if (!Project.CanAccess(user))
                 {
-                    if (!Project.CanAccess(user))
-                    {
-                        error = "The user does not have access to the project.";
-                        return false;
-                    }
-                    if (_activeSessions.TryGetValue(modelSystemHeader, out var mss))
-                    {
-                        error = "The model system is currently being edited and can not be exported.";
-                        return false;
-                    }
-                    var tempDir = new DirectoryInfo(tempDirName);
-                    if (!tempDir.Exists)
-                    {
-                        tempDir.Create();
-                    }
-                    // copy in the model system file
-                    File.Copy(modelSystemHeader.ModelSystemPath, Path.Combine(tempDir.FullName, ModelSystemFileStrings.ModelSystemFile));
-                    using (var metadataStream = File.OpenWrite(Path.Combine(tempDir.FullName, ModelSystemFileStrings.MetaDataFile)))
-                    using (var writer = new Utf8JsonWriter(metadataStream))
-                    {
-                        writer.WriteStartObject();
-                        writer.WriteString(ModelSystemFileStrings.Name, modelSystemHeader.Name);
-                        writer.WriteString(ModelSystemFileStrings.Description, modelSystemHeader.Description);
-                        writer.WriteString(ModelSystemFileStrings.ExportedOn, DateTime.UtcNow);
-                        writer.WriteString(ModelSystemFileStrings.ExportedBy, user.UserName);
-                        writer.WriteNumber(ModelSystemFileStrings.VersionMajor, fvi.FileMajorPart);
-                        writer.WriteNumber(ModelSystemFileStrings.VersionMinor, fvi.FileMinorPart);
-                        writer.WriteEndObject();
-                    }
-                    // Zip the temporary directory and store it.
-                    ZipFile.CreateFromDirectory(tempDirName, exportPath);
-                    return true;
+                    error = "The user does not have access to the project.";
+                    return false;
                 }
-            }
-            catch (IOException e)
-            {
-                error = e.Message;
-            }
-            finally
-            {
-                // Try to clean up the temporary directory if it still exists.
-                try
+                if (_activeSessions.TryGetValue(modelSystemHeader, out var mss))
                 {
-                    var tempDir = new DirectoryInfo(tempDirName);
-                    if (tempDir.Exists)
-                    {
-                        tempDir.Delete(true);
-                    }
+                    error = "The model system is currently being edited and can not be exported.";
+                    return false;
                 }
-                /*
-                 * This will warn that we should catch a more specific exception however there is no recovery in any case.
-                 * The operation has already been successful even if we are unable to clean up the temporary storage.
-                 */
-                #pragma warning disable CA1031
-                catch (IOException)
-                
-                {
-                    // If we don't have access to the temporary storage there is nothing else that we can do.
-                }
-                #pragma warning restore CA1031
+                return ModelSystemFile.ExportModelSystem(this, user, modelSystemHeader, exportPath, ref error);
             }
-            return false;
         }
 
         /// <summary>
@@ -517,8 +421,9 @@ namespace XTMF2.Editing
             }
         }
 
-        public bool ImportModelSystem(User user, string fullName, string modelSystemName, out ModelSystemHeader header)
+        public bool ImportModelSystem(User user, string fullName, string modelSystemName, out ModelSystemHeader header, ref string error)
         {
+            header = null;
             if (user is null)
             {
                 throw new ArgumentNullException(nameof(user));
@@ -533,7 +438,29 @@ namespace XTMF2.Editing
             {
                 throw new ArgumentException(nameof(modelSystemName));
             }
-            throw new NotImplementedException();
+            try
+            {
+                using var archive = ZipFile.OpenRead(fullName);
+                lock (_sessionLock)
+                {
+                    if (!HasAccess(user))
+                    {
+                        error = "The user that issued the command does not have access to this project.";
+                        return false;
+                    }
+
+                }
+                return true;
+            }
+            catch (InvalidDataException e)
+            {
+                error = e.Message;
+            }
+            catch (IOException e)
+            {
+                error = e.Message;
+            }
+            return false;
         }
     }
 }

--- a/src/XTMF2/ModelSystemFile.cs
+++ b/src/XTMF2/ModelSystemFile.cs
@@ -1,0 +1,166 @@
+﻿/*
+    Copyright 2019 University of Toronto
+
+    This file is part of XTMF2.
+
+    XTMF2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF2.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.IO.Compression;
+using XTMF2.Editing;
+using System.IO;
+using System.Diagnostics;
+
+namespace XTMF2
+{
+    /// <summary>
+    /// This class is designed for interacting with model systems that have been exported.
+    /// </summary>
+    public sealed class ModelSystemFile
+    {
+        /// <summary>
+        /// A string used for the meta-data to gather the name of the model system.
+        /// </summary>
+        internal const string PropertyName = "Name";
+        /// <summary>
+        /// A string used in the meta-data to provide a description of the model system.
+        /// </summary>
+        internal const string PropertyDescription = "Description";
+        /// <summary>
+        /// A string used in the meta-data to give the name of the user that exported the model system
+        /// </summary>
+        internal const string PropertyExportedBy = "ExportedBy";
+        /// <summary>
+        /// A string used by the meta-data to give what time in UTC that the model system was exported at.
+        /// </summary>
+        internal const string PropertyExportedOn = "ExportedOn";
+        /// <summary>
+        /// A string used by the meta-data to indicate what version of XTMF exported the model system.
+        /// </summary>
+        internal const string PropertyVersionMajor = "VersionMajor";
+        /// <summary>
+        /// A string used by the meta-data to indicate what version of XTMF exported the model system.
+        /// </summary>
+        internal const string PropertyVersionMinor = "VersionMinor";
+
+        /// <summary>
+        /// The name of the file within the archive for where the model system was stored.
+        /// </summary>
+        internal const string ModelSystemFilePath = "ModelSystem.xmsys";
+        /// <summary>
+        /// The name of the file within the archive for where the meta-data was stored.
+        /// </summary>
+        internal const string MetaDataFilePath = "metadata.json";
+
+        /// <summary>
+        /// The name of the model system that was exported
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The description of the model system that was exported
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// The name of the user that exported the model system.
+        /// </summary>
+        public string ExportedBy { get; }
+
+        /// <summary>
+        /// The time that the model system was exported.
+        /// </summary>
+        public DateTime ExportedOn { get; }
+
+        /// <summary>
+        /// The version number (X.Y) of XTMF that exported the model system.
+        /// </summary>
+        public (int Major, int Minor) ExportingXTMFVersion { get; }
+
+        /// <summary>
+        /// Export the model system to the given path.
+        /// </summary>
+        /// <param name="projectSession">An editing session for the project that is being exported from.</param>
+        /// <param name="user">The use that is exporting. Permissions are not checked.</param>
+        /// <param name="modelSystemHeader">The header for the model system that is to be exported.</param>
+        /// <param name="exportPath">The path to export the model system to.</param>
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise with an error message.</returns>
+        internal static bool ExportModelSystem(ProjectSession projectSession, User user,
+            ModelSystemHeader modelSystemHeader, string exportPath, ref string error)
+        {
+            var tempDirName = string.Empty;
+            try
+            {
+                var project = projectSession.Project;
+                tempDirName = Path.Combine(Path.GetTempPath(), "XTMF-" + project.Name + modelSystemHeader.Name + Guid.NewGuid());
+                System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+                FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+                var tempDir = new DirectoryInfo(tempDirName);
+                if (!tempDir.Exists)
+                {
+                    tempDir.Create();
+                }
+                // copy in the model system file
+                File.Copy(modelSystemHeader.ModelSystemPath, Path.Combine(tempDir.FullName, ModelSystemFilePath));
+                using (var metadataStream = File.OpenWrite(Path.Combine(tempDir.FullName, MetaDataFilePath)))
+                using (var writer = new Utf8JsonWriter(metadataStream))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString(PropertyName, modelSystemHeader.Name);
+                    writer.WriteString(PropertyDescription, modelSystemHeader.Description);
+                    writer.WriteString(PropertyExportedOn, DateTime.UtcNow);
+                    writer.WriteString(PropertyExportedBy, user.UserName);
+                    writer.WriteNumber(PropertyVersionMajor, fvi.FileMajorPart);
+                    writer.WriteNumber(PropertyVersionMinor, fvi.FileMinorPart);
+                    writer.WriteEndObject();
+                }
+                // Zip the temporary directory and store it.
+                ZipFile.CreateFromDirectory(tempDirName, exportPath);
+                return true;
+            }
+            catch (IOException e)
+            {
+                error = e.Message;
+            }
+            finally
+            {
+                // Try to clean up the temporary directory if it still exists.
+                try
+                {
+                    var tempDir = new DirectoryInfo(tempDirName);
+                    if (tempDir.Exists)
+                    {
+                        tempDir.Delete(true);
+                    }
+                }
+                /*
+                 * This will warn that we should catch a more specific exception however there is no recovery in any case.
+                 * The operation has already been successful even if we are unable to clean up the temporary storage.
+                 */
+#pragma warning disable CA1031
+                catch (IOException)
+
+                {
+                    // If we don't have access to the temporary storage there is nothing else that we can do.
+                }
+#pragma warning restore CA1031
+            }
+            return false;
+        }
+    }
+}

--- a/src/XTMF2/Project.cs
+++ b/src/XTMF2/Project.cs
@@ -354,5 +354,42 @@ namespace XTMF2
             _ModelSystems.Add(modelSystemHeader);
             return true;
         }
+
+        /// <summary>
+        /// Add a model system to the project from a model system file.
+        /// </summary>
+        /// <param name="projectSession">The project session that the model system is going into.</param>
+        /// <param name="modelSystemName">The name to use for the new model system.  It must be unique.</param>
+        /// <param name="msf">The model system file to use.</param>
+        /// <param name="header">A model system header to the newly imported model system.</param>
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise.</returns>
+        internal bool AddModelSystemFromModelSystemFile(ProjectSession projectSession, string modelSystemName, 
+            ModelSystemFile msf, out ModelSystemHeader header, ref string error)
+        {
+            header = null;
+            if (projectSession is null)
+            {
+                throw new ArgumentNullException(nameof(projectSession));
+            }
+
+            if (msf is null)
+            {
+                throw new ArgumentNullException(nameof(msf));
+            }
+            if(ContainsModelSystem(modelSystemName))
+            {
+                error = "A model system with this name already exists!";
+                return false;
+            }
+            var tempHeader = new ModelSystemHeader(this, modelSystemName, msf.Description);
+            if(!msf.ExtractModelSystemTo(tempHeader.ModelSystemPath, ref error))
+            {
+                return false;
+            }
+            _ModelSystems.Add(tempHeader);
+            header = tempHeader;
+            return true;
+        }
     }
 }

--- a/tests/XTMF2.UnitTests/TestModelSystem.cs
+++ b/tests/XTMF2.UnitTests/TestModelSystem.cs
@@ -487,7 +487,7 @@ namespace XTMF2
                         Assert.IsTrue(session.Save(ref error), error);
                     }
                     Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
-                    Assert.IsTrue(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader), error);
+                    Assert.IsTrue(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error), error);
                     Assert.IsNotNull(importedHeader, "The model system header was not set!");
                     Assert.AreEqual(importedName, importedHeader.Name, "The name of the imported model system was not the same as what was specified.");
                     Assert.AreEqual(description, importedHeader.Description);
@@ -534,7 +534,7 @@ namespace XTMF2
                         Assert.IsTrue(session.Save(ref error), error);
                     }
                     Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
-                    Assert.IsFalse(project.ImportModelSystem(unauthorizedUser, tempFile.FullName, importedName, out ModelSystemHeader importedHeader),
+                    Assert.IsFalse(project.ImportModelSystem(unauthorizedUser, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
                         "An unauthorized user was able to import a model system!");
                     Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
                 }
@@ -562,7 +562,7 @@ namespace XTMF2
                 Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
-                Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader),
+                Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
                     "An unauthorized user was able to import a model system!");
                 Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
             });
@@ -583,11 +583,12 @@ namespace XTMF2
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 var tempDir = new FileInfo(Path.GetTempFileName());
                 tempDir.Delete();
+                tempFile.Delete();
                 try
                 {
                     Directory.CreateDirectory(tempDir.FullName);
                     ZipFile.CreateFromDirectory(tempDir.FullName, tempFile.FullName);
-                    Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader),
+                    Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
                         "An unauthorized user was able to import a model system!");
                     Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
                 }


### PR DESCRIPTION
An implementation for issue #42.

It also refactors the model system exporting logic into a new class "ModelSystemFile" to provide an abstraction that can be used later on for getting the meta-data from a model system file but not loading the model system into a project.