### PR TITLE
Switched to System.Text.Json for reading/writing model systems.

### DIFF
--- a/src/XTMF2/Controllers/ProjectController.cs
+++ b/src/XTMF2/Controllers/ProjectController.cs
@@ -221,7 +221,12 @@ namespace XTMF2.Controllers
         /// <param name="projectSession"></param>
         internal void UnloadSession(ProjectSession projectSession)
         {
-            ActiveSessions.Remove(projectSession.Project);
+            var project = projectSession.Project;
+            // The project will be null if we are running the model system.
+            if (!(project is null))
+            {
+                ActiveSessions.Remove(project);
+            }
         }
 
         private string GetPath(User owner, string name)

--- a/src/XTMF2/ModelSystemConstruct/MultiLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/MultiLink.cs
@@ -19,7 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -54,24 +54,21 @@ namespace XTMF2.ModelSystemConstruct
             return true;
         }
 
-        internal override void Save(Dictionary<Node, int> moduleDictionary, JsonTextWriter writer)
+        internal override void Save(Dictionary<Node, int> moduleDictionary, Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("Origin");
-            writer.WriteValue(moduleDictionary[Origin]);
-            writer.WritePropertyName("Hook");
-            writer.WriteValue(OriginHook.Name);
-            writer.WritePropertyName("Destination");
+            writer.WriteNumber(OriginProperty, moduleDictionary[Origin]);
+            writer.WriteString(HookProperty, OriginHook.Name);
+            writer.WritePropertyName(DestinationProperty);
             writer.WriteStartArray();
             foreach (var dest in _Destinations)
             {
-                writer.WriteValue(moduleDictionary[dest]);
+                writer.WriteNumberValue(moduleDictionary[dest]);
             }
             writer.WriteEndArray();
             if (IsDisabled)
             {
-                writer.WritePropertyName("Disabled");
-                writer.WriteValue(true);
+                writer.WriteBoolean(DisabledProperty, true);
             }
             writer.WriteEndObject();
         }

--- a/src/XTMF2/ModelSystemConstruct/SingleLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/SingleLink.cs
@@ -19,7 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
 using XTMF2.Editing;
 using System.ComponentModel;
 
@@ -35,19 +35,15 @@ namespace XTMF2.ModelSystemConstruct
             return true;
         }
 
-        internal override void Save(Dictionary<Node, int> moduleDictionary, JsonTextWriter writer)
+        internal override void Save(Dictionary<Node, int> moduleDictionary, Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("Origin");
-            writer.WriteValue(moduleDictionary[Origin]);
-            writer.WritePropertyName("Hook");
-            writer.WriteValue(OriginHook.Name);
-            writer.WritePropertyName("Destination");
-            writer.WriteValue(moduleDictionary[Destination]);
+            writer.WriteNumber(OriginProperty, moduleDictionary[Origin]);
+            writer.WriteString(HookProperty, OriginHook.Name);
+            writer.WriteNumber(DestinationProperty, moduleDictionary[Destination]);
             if (IsDisabled)
             {
-                writer.WritePropertyName("Disabled");
-                writer.WriteValue(true);
+                writer.WriteBoolean(DisabledProperty, true);
             }
             writer.WriteEndObject();
         }


### PR DESCRIPTION
Switched to System.Text.Json for reading/writing model systems. #44 

Fixed an issue with project sessions that are created for a run context.  They were not being property unloaded.