### PR TITLE
Add Method RemoveModelSystem to Project Session

### DIFF
--- a/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
@@ -226,7 +226,7 @@ namespace XTMF2.Editing
             Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem("TestMS", out var modelSystem, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
@@ -253,7 +253,7 @@ namespace XTMF2.Editing
             Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem("TestMS", out var modelSystem, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
@@ -274,7 +274,7 @@ namespace XTMF2.Editing
             Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem("TestMS", out var modelSystem, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
@@ -301,7 +301,7 @@ namespace XTMF2.Editing
             Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem("TestMS", out var modelSystem, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
@@ -329,7 +329,7 @@ namespace XTMF2.Editing
                 Assert.IsTrue(controller.CreateNewProject(localUser, projectName, out ProjectSession session, ref error).UsingIf(session, () =>
                 {
                     var project = session.Project;
-                    Assert.IsTrue(session.CreateNewModelSystem(modelSystemName, out var modelSystem, ref error), error);
+                    Assert.IsTrue(session.CreateNewModelSystem(localUser, modelSystemName, out var modelSystem, ref error), error);
                     Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
                         {
                             var ms = msSession.ModelSystem;

--- a/tests/XTMF2.UnitTests/TestHelper.cs
+++ b/tests/XTMF2.UnitTests/TestHelper.cs
@@ -185,7 +185,7 @@ namespace XTMF2
             {
                 Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                     Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
                     {
                         toExecute(user, projectSession, modelSystemSession);
@@ -223,7 +223,7 @@ namespace XTMF2
             {
                 Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                     Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
                     {
                         toExecute(user, unauthorizedUser, projectSession, modelSystemSession);
@@ -316,7 +316,7 @@ namespace XTMF2
             {
                 Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                     Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
                     {
                         toExecuteFirst(user, projectSession, modelSystemSession);

--- a/tests/XTMF2.UnitTests/TestModelSystem.cs
+++ b/tests/XTMF2.UnitTests/TestModelSystem.cs
@@ -47,7 +47,7 @@ namespace XTMF2
             Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
             Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, ref error).UsingIf(session, () =>
             {
-                Assert.IsTrue(session.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                 Assert.IsTrue(session.Save(ref error));
             }), error);
             runtime.Shutdown();
@@ -98,7 +98,7 @@ namespace XTMF2
                 // share the session with the second user
                 Assert.IsTrue(session.ShareWith(user, user2, ref error), error);
                 // create a new model system for both users to try to edit
-                Assert.IsTrue(session.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(
                     modelSystemSession, () =>
                     {
@@ -135,7 +135,7 @@ namespace XTMF2
                 // share the session with the second user
                 Assert.IsTrue(session.ShareWith(user, user2, ref error), error);
                 // create a new model system for both users to try to edit
-                Assert.IsTrue(session.CreateNewModelSystem(modelSystemName, out var modelSystemHeader, ref error), error);
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
                 Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(
                     modelSystemSession, () =>
                     {
@@ -293,7 +293,7 @@ namespace XTMF2
                 var msName = "MSToExport";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
@@ -340,7 +340,7 @@ namespace XTMF2
                 var startName = "MyStart";
                 var nodeName = "MyNode";
                 var msDescription = "Description of the model system";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(msHeader.SetDescription(project, msDescription, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 FileInfo tempFile = new FileInfo(Path.GetTempFileName());
@@ -467,7 +467,7 @@ namespace XTMF2
                 var description = "A test model system.";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
@@ -514,7 +514,7 @@ namespace XTMF2
                 var description = "A test model system.";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
@@ -558,7 +558,7 @@ namespace XTMF2
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
@@ -577,7 +577,7 @@ namespace XTMF2
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
                 Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
                 var tempFile = new FileInfo(Path.GetTempFileName());
@@ -615,7 +615,7 @@ namespace XTMF2
                 string error = null;
                 var msName = "MSToExport";
                 var newName = "NewMSName";
-                Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
                 Assert.AreEqual(msName, msHeader.Name);
                 Assert.IsTrue(project.RenameModelSystem(user, msHeader, newName, ref error), error);
                 Assert.AreEqual(newName, msHeader.Name);

--- a/tests/XTMF2.UnitTests/TestProjects.cs
+++ b/tests/XTMF2.UnitTests/TestProjects.cs
@@ -160,7 +160,7 @@ namespace XTMF2
             string error = null;
             var startName = "MyStart";
             var nodeName = "MyNode";
-            Assert.IsTrue(project.CreateNewModelSystem(msName, out var msHeader, ref error), error);
+            Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
             Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
             Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
             using (session)
@@ -494,6 +494,22 @@ namespace XTMF2
                         dir.Delete();
                     }
                 }
+            });
+        }
+
+        [TestMethod]
+        public void RemoveModelSystem()
+        {
+            TestHelper.RunInProjectContext("RemoveModelSystem", (User user, ProjectSession project) =>
+            {
+                const string msName = "RemoveMe";
+                string error = null;
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error).UsingIf(session, ()=>
+                {
+                    Assert.IsFalse(project.RemoveModelSystem(user, msHeader, ref error), "A model system was able to be removed while it was being edited!");
+                }), error);
+                Assert.IsTrue(project.RemoveModelSystem(user, msHeader, ref error), error);
             });
         }
     }


### PR DESCRIPTION
Added a command to the ProjectSession to remove a model system from a project.

Added a the user as the first parameter for CreateModelSystem.  This is a breaking change for third party code.