### PR TITLE
Change Namespaces for Test Modules

### DIFF
--- a/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
@@ -18,8 +18,9 @@
 */
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using XTMF2.Editing;
 
-namespace XTMF2.Editing
+namespace XTMF2.UnitTests.Editing
 {
     [TestClass]
     public class TestBoundaries

--- a/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
@@ -20,7 +20,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using XTMF2.ModelSystemConstruct;
 
-namespace XTMF2.Editing
+namespace XTMF2.UnitTests.Editing
 {
     [TestClass]
     public class TestCommentBlock

--- a/tests/XTMF2.UnitTests/Editing/TestLinks.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestLinks.cs
@@ -20,12 +20,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using XTMF2.Modules;
+using XTMF2.UnitTests.Modules;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.RuntimeModules;
 
 
-namespace XTMF2.Editing
+namespace XTMF2.UnitTests.Editing
 {
     [TestClass]
     public class TestLinks

--- a/tests/XTMF2.UnitTests/Editing/TestNode.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestNode.cs
@@ -19,11 +19,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Threading;
-using XTMF2.Modules;
+using XTMF2.UnitTests.Modules;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.RuntimeModules;
 
-namespace XTMF2.Editing
+namespace XTMF2.UnitTests.Editing
 {
     [TestClass]
     public class TestNode

--- a/tests/XTMF2.UnitTests/Modules/FailsAtRuntime.cs
+++ b/tests/XTMF2.UnitTests/Modules/FailsAtRuntime.cs
@@ -20,7 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace XTMF2.Modules
+namespace XTMF2.UnitTests.Modules
 {
     [Module(Name = "Fails At Runtime", DocumentationLink = "http://tmg.utoronto.ca/doc/2.0",
     Description = "A test module to cause an XTMFRuntime exception at runtime.")]

--- a/tests/XTMF2.UnitTests/Modules/FailsAtRuntimeValidation.cs
+++ b/tests/XTMF2.UnitTests/Modules/FailsAtRuntimeValidation.cs
@@ -20,7 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace XTMF2.Modules
+namespace XTMF2.UnitTests.Modules
 {
     [Module(Name = "Fails At Runtime Validation", DocumentationLink = "http://tmg.utoronto.ca/doc/2.0",
 Description = "A test module to cause an XTMFRuntime exception at run time validation.")]

--- a/tests/XTMF2.UnitTests/Modules/SimpleParameterModule.cs
+++ b/tests/XTMF2.UnitTests/Modules/SimpleParameterModule.cs
@@ -20,7 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace XTMF2.Modules
+namespace XTMF2.UnitTests.Modules
 {
     [Module(Name = "Simple Parameter Module", DocumentationLink = "http://tmg.utoronto.ca/doc/2.0",
         Description = "A test module to invoke a function that returns a string.")]

--- a/tests/XTMF2.UnitTests/Modules/SimpleTestModule.cs
+++ b/tests/XTMF2.UnitTests/Modules/SimpleTestModule.cs
@@ -20,7 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace XTMF2.Modules
+namespace XTMF2.UnitTests.Modules
 {
     [Module(Name = "Simple Test Module", DocumentationLink = "http://tmg.utoronto.ca/doc/2.0",
     Description = "A test module to invoke a function that returns a string.")]

--- a/tests/XTMF2.UnitTests/RuntimeModules/TestFileStreams.cs
+++ b/tests/XTMF2.UnitTests/RuntimeModules/TestFileStreams.cs
@@ -18,9 +18,10 @@
 */
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
-using static XTMF2.TestHelper;
+using XTMF2.RuntimeModules;
+using static XTMF2.UnitTests.TestHelper;
 
-namespace XTMF2.RuntimeModules
+namespace XTMF2.UnitTests.RuntimeModules
 {
     [TestClass]
     public class TestFileStreams

--- a/tests/XTMF2.UnitTests/TestHelper.cs
+++ b/tests/XTMF2.UnitTests/TestHelper.cs
@@ -29,7 +29,7 @@ using XTMF2.Bus;
 using XTMF2.Editing;
 using XTMF2.RuntimeModules;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     static class TestHelper
     {

--- a/tests/XTMF2.UnitTests/TestModelSystem.cs
+++ b/tests/XTMF2.UnitTests/TestModelSystem.cs
@@ -23,11 +23,11 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using XTMF2.ModelSystemConstruct;
-using XTMF2.Modules;
+using XTMF2.UnitTests.Modules;
 using XTMF2.RuntimeModules;
-using static XTMF2.TestHelper;
+using static XTMF2.UnitTests.TestHelper;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     [TestClass]
     public class TestModelSystem

--- a/tests/XTMF2.UnitTests/TestProjects.cs
+++ b/tests/XTMF2.UnitTests/TestProjects.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using XTMF2.Editing;
 using XTMF2.RuntimeModules;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     [TestClass]
     public class TestProjects

--- a/tests/XTMF2.UnitTests/TestRun.cs
+++ b/tests/XTMF2.UnitTests/TestRun.cs
@@ -20,11 +20,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Threading;
 using XTMF2.ModelSystemConstruct;
-using XTMF2.Modules;
+using XTMF2.UnitTests.Modules;
 using XTMF2.RuntimeModules;
-using static XTMF2.TestHelper;
+using static XTMF2.UnitTests.TestHelper;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     [TestClass]
     public class TestRun

--- a/tests/XTMF2.UnitTests/TestUsers.cs
+++ b/tests/XTMF2.UnitTests/TestUsers.cs
@@ -23,7 +23,7 @@ using XTMF2.Editing;
 using XTMF2.Controllers;
 using System.Linq;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     [TestClass]
     public class TestUsers

--- a/tests/XTMF2.UnitTests/TestXTMFRuntime.cs
+++ b/tests/XTMF2.UnitTests/TestXTMFRuntime.cs
@@ -20,7 +20,7 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using XTMF2;
 
-namespace XTMF2
+namespace XTMF2.UnitTests
 {
     [TestClass]
     public class TestXTMFRuntime

--- a/tests/XTMF2.UnitTests/XTMF2.UnitTests.csproj
+++ b/tests/XTMF2.UnitTests/XTMF2.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <RootNamespace>XTMF2</RootNamespace>
+    <RootNamespace>XTMF2.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR changes the namespace for all unit test code from XTMF2.* into XTMF2.UnitTests.*.