### PR TITLE
Set Comment Block Location and Comment Text

### DIFF
--- a/src/XTMF2/Editing/ModelSystemSession.cs
+++ b/src/XTMF2/Editing/ModelSystemSession.cs
@@ -302,6 +302,95 @@ namespace XTMF2.Editing
         }
 
         /// <summary>
+        /// Sets the location of the CommentBlock
+        /// </summary>
+        /// <param name="user">The user issuing the command.</param>
+        /// <param name="commentBlock">The comment block to change.</param>
+        /// <param name="newLocation">The location to set the comment block to.</param>
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise with an error message.</returns>
+        public bool SetCommentBlockLocation(User user, CommentBlock commentBlock, Point newLocation, ref string error)
+        {
+            if (user is null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            if (commentBlock is null)
+            {
+                throw new ArgumentNullException(nameof(commentBlock));
+            }
+
+            lock (_sessionLock)
+            {
+                if (!_session.HasAccess(user))
+                {
+                    error = "The user does not have access to this project.";
+                    return false;
+                }
+                var oldLocation = commentBlock.Location;
+                commentBlock.Location = newLocation;
+                Buffer.AddUndo(new Command(() =>
+                {
+                    commentBlock.Location = oldLocation;
+                    return (true, null);
+                }, () =>
+                {
+                    commentBlock.Location = newLocation;
+                    return (true, null);
+                }));
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Set the comment text within a comment block
+        /// </summary>
+        /// <param name="user">The using issuing the command.</param>
+        /// <param name="commentBlock">The comment block to edit.</param>
+        /// <param name="newText">The new text to set.</param>
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise with an error message.</returns>
+        public bool SetCommentBlockText(User user, CommentBlock commentBlock, string newText, ref string error)
+        {
+            if (user is null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            if (commentBlock is null)
+            {
+                throw new ArgumentNullException(nameof(commentBlock));
+            }
+
+            if (string.IsNullOrEmpty(newText))
+            {
+                error = "A comment block must have text!";
+                return false;
+            }
+            lock(_sessionLock)
+            {
+                if(!_session.HasAccess(user))
+                {
+                    error = "The user does not have access to this project.";
+                    return false;
+                }
+                var oldComment = commentBlock.Comment;
+                commentBlock.Comment = newText;
+                Buffer.AddUndo(new Command(() =>
+              {
+                  commentBlock.Comment = oldComment;
+                  return (true, null);
+              }, () =>
+              {
+                  commentBlock.Comment = newText;
+                  return (true, null);
+              }));
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Remove a boundary from a model system
         /// </summary>
         /// <param name="user">The user that removed the boundary</param>

--- a/src/XTMF2/ModelSystemConstruct/CommentBlock.cs
+++ b/src/XTMF2/ModelSystemConstruct/CommentBlock.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using XTMF2.Editing;
@@ -27,11 +28,13 @@ namespace XTMF2.ModelSystemConstruct
     /// <summary>
     /// This class is used to add comments inside of a boundary
     /// </summary>
-    public sealed class CommentBlock
+    public sealed class CommentBlock : INotifyPropertyChanged
     {
         private const string XProperty = "X";
         private const string YProperty = "Y";
         private const string CommentProperty = "Comment";
+
+        public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
         /// Construct a new comments block
@@ -45,14 +48,42 @@ namespace XTMF2.ModelSystemConstruct
         }
 
         /// <summary>
+        /// Invoke this when a property is changed
+        /// </summary>
+        /// <param name="propertyName">The name of the property that was changed</param>
+        private void Notify(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private Point _location;
+        private string _comment;
+
+        /// <summary>
         /// The location to place the Comment Block within the boundary
         /// </summary>
-        public Point Location { get; set; }
+        public Point Location
+        {
+            get => _location;
+            set
+            {
+                _location = value;
+                Notify(nameof(Location));
+            }
+        }
 
         /// <summary>
         /// The comment string to display
         /// </summary>
-        public string Comment { get; private set; }
+        public string Comment
+        {
+            get => _comment;
+            set
+            {
+                _comment = value;
+                Notify(nameof(Comment));
+            }
+        }
 
         internal void Save(Utf8JsonWriter writer)
         {
@@ -69,13 +100,13 @@ namespace XTMF2.ModelSystemConstruct
             string comment = "No comment";
             while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
             {
-                if(reader.TokenType == JsonTokenType.Comment)
+                if (reader.TokenType == JsonTokenType.Comment)
                 {
                     continue;
                 }
-                if(reader.TokenType == JsonTokenType.PropertyName)
+                if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    if(reader.ValueTextEquals(XProperty))
+                    if (reader.ValueTextEquals(XProperty))
                     {
                         reader.Read();
                         x = reader.GetSingle();

--- a/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
@@ -173,5 +173,53 @@ namespace XTMF2.UnitTests.Editing
                 Assert.AreEqual(0, comBlocks.Count);
             });
         }
+
+        [TestMethod]
+        public void TestChangingCommentBlockText()
+        {
+            TestHelper.RunInModelSystemContext("TestChangingCommentBlockText", (user, pSession, msSession) =>
+            {
+                string error = null;
+                var ms = msSession.ModelSystem;
+                var comment = "My Comment";
+                var newComment = "New comment";
+                var location = new Point(100, 100);
+                var comBlocks = ms.GlobalBoundary.CommentBlocks;
+                Assert.AreEqual(0, comBlocks.Count);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.AreEqual(1, comBlocks.Count);
+                Assert.AreEqual(comment, comBlocks[0].Comment);
+                Assert.IsTrue(msSession.SetCommentBlockText(user, block, newComment, ref error), error);
+                Assert.AreEqual(newComment, block.Comment, "The comment block's text was not set!");
+                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.AreEqual(comment, block.Comment, "The comment block's text was not undone!");
+                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.AreEqual(newComment, block.Comment);
+            });
+        }
+
+        [TestMethod]
+        public void TestChangingCommentBlockPosition()
+        {
+            TestHelper.RunInModelSystemContext("TestChangingCommentBlockPosition", (user, pSession, msSession) =>
+            {
+                string error = null;
+                var ms = msSession.ModelSystem;
+                var comment = "My Comment";
+                var location = new Point(100, 100);
+                var newLocation = new Point(100, 200);
+                var comBlocks = ms.GlobalBoundary.CommentBlocks;
+                Assert.AreEqual(0, comBlocks.Count);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.AreEqual(1, comBlocks.Count);
+                Assert.AreEqual(comment, comBlocks[0].Comment);
+                Assert.IsTrue(msSession.SetCommentBlockLocation(user, block, newLocation, ref error), error);
+                Assert.AreEqual(newLocation, block.Location, "The comment block's location was not set!");
+                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.AreEqual(location, block.Location, "The comment block's location was not undone!");
+                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.AreEqual(newLocation, block.Location);
+            });
+        }
     }
 }


### PR DESCRIPTION
Added are two new methods for the ModelSystemEditingSession allowing for the setting of the location and text for comment blocks.