### PR TITLE
Switch Error Message to CommandError

### DIFF
--- a/src/XTMF2/Bus/HostBus.cs
+++ b/src/XTMF2/Bus/HostBus.cs
@@ -215,7 +215,7 @@ namespace XTMF2.Bus
         /// <param name="id">The ID given to this model run.</param>
         /// <param name="error">An error message if there is an issue creating the model system.</param>
         /// <returns>True if the model system was sent</returns>
-        public bool RunModelSystem(ModelSystemSession modelSystem, string cwd, string startToExecute, out string id, ref string error)
+        public bool RunModelSystem(ModelSystemSession modelSystem, string cwd, string startToExecute, out string id, out CommandError error)
         {
             id = null;
             lock (_outLock)
@@ -224,7 +224,7 @@ namespace XTMF2.Bus
                 {
                     using var memStream = new MemoryStream();
                     using var write = new BinaryWriter(memStream, Encoding.UTF8, true);
-                    if (!modelSystem.Save(ref error, memStream))
+                    if (!modelSystem.Save(out error, memStream))
                     {
                         return false;
                     }
@@ -241,7 +241,7 @@ namespace XTMF2.Bus
                 }
                 catch (IOException e)
                 {
-                    error = e.Message;
+                    error = new CommandError(e.Message);
                     return false;
                 }
             }

--- a/src/XTMF2/Configuration/User.cs
+++ b/src/XTMF2/Configuration/User.cs
@@ -22,6 +22,7 @@ using System.Collections.ObjectModel;
 using System.Text.Json;
 using System.Linq;
 using System.IO;
+using XTMF2.Editing;
 
 namespace XTMF2
 {
@@ -174,7 +175,7 @@ namespace XTMF2
         /// </summary>
         /// <param name="error">The error message in case of failure.</param>
         /// <returns>True if successful, false otherwise with an error message.</returns>
-        internal bool Save(ref string error)
+        internal bool Save(out CommandError error)
         {
             var temp = Path.GetTempFileName();
             try
@@ -194,11 +195,12 @@ namespace XTMF2
                 }
                 // when we have complete copy the results
                 File.Copy(temp, Path.Combine(UserPath, "User.xusr"), true);
+                error = null;
                 return true;
             }
             catch (IOException e)
             {
-                error = e.Message;
+                error = new CommandError(e.Message);
                 return false;
             }
             finally

--- a/src/XTMF2/Editing/Command.cs
+++ b/src/XTMF2/Editing/Command.cs
@@ -27,16 +27,16 @@ namespace XTMF2.Editing
     /// </summary>
     public sealed class Command
     {
-        internal Func<(bool Success, string Message)> Undo;
-        internal Func<(bool Success, string Message)> Redo;
+        internal Func<(bool Success, CommandError Error)> Undo;
+        internal Func<(bool Success, CommandError Error)> Redo;
         /// <summary>
         /// Create a new command with the given delegates
         /// </summary>
         /// <param name="Undo">The logic to undo the command.</param>
         /// <param name="Redo">The logic to redo the command.</param>
         public Command(
-            Func<(bool Success, string Message)> Undo,
-            Func<(bool Success, string Message)> Redo
+            Func<(bool Success, CommandError Error)> Undo,
+            Func<(bool Success, CommandError Error)> Redo
             )
         {
             if (Undo == null || Redo == null)

--- a/src/XTMF2/Editing/CommandBatch.cs
+++ b/src/XTMF2/Editing/CommandBatch.cs
@@ -56,17 +56,18 @@ namespace XTMF2.Editing
         /// </summary>
         /// <param name="error">An error message if the undo fails.</param>
         /// <returns>True if successful, false otherwise with an error message.</returns>
-        public bool Undo(ref string error)
+        public bool Undo(out CommandError error)
         {
             foreach (var command in _Commands)
             {
                 var result = command.Undo();
                 if (!result.Success)
                 {
-                    error = result.Message;
+                    error = result.Error;
                     return false;
                 }
             }
+            error = null;
             return true;
         }
 
@@ -75,17 +76,18 @@ namespace XTMF2.Editing
         /// </summary>
         /// <param name="error">An error message if the redo fails.</param>
         /// <returns>True if successful, false otherwise with an error message.</returns>
-        public bool Redo(ref string error)
+        public bool Redo(out CommandError error)
         {
             foreach (var command in _Commands)
             {
                 var result = command.Redo();
                 if (!result.Success)
                 {
-                    error = result.Message;
+                    error = result.Error;
                     return false;
                 }
             }
+            error = null;
             return true;
         }
     }

--- a/src/XTMF2/Editing/CommandError.cs
+++ b/src/XTMF2/Editing/CommandError.cs
@@ -1,0 +1,63 @@
+﻿/*
+    Copyright 2020 University of Toronto
+
+    This file is part of XTMF2.
+
+    XTMF2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF2.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XTMF2.Editing
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class CommandError
+    {
+        /// <summary>
+        /// Create a new error report to the issuing program.
+        /// </summary>
+        /// <param name="message">A message that describes the error.</param>
+        /// <param name="unauthorizedUser">True if the user was not authorized to issue the command.</param>
+        public CommandError(string message, bool unauthorizedUser = false)
+        {
+            Message = message;
+            UnauthorizedUser = unauthorizedUser;
+        }
+
+        /// <summary>
+        /// An message about why the command failed.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// True if the user was not authorized to issue the command.
+        /// </summary>
+        public bool UnauthorizedUser { get; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CommandError error &&
+                   Message == error.Message &&
+                   UnauthorizedUser == error.UnauthorizedUser;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Message, UnauthorizedUser);
+        }
+    }
+}

--- a/src/XTMF2/ModelSystemConstruct/Boundary.cs
+++ b/src/XTMF2/ModelSystemConstruct/Boundary.cs
@@ -209,6 +209,7 @@ namespace XTMF2
                         return false;
                     }
                 }
+                error = null;
                 return true;
             }
         }
@@ -225,22 +226,23 @@ namespace XTMF2
         /// <param name="boundary">The resulting boundary.</param>
         /// <param name="error">An error message if the operation fails.</param>
         /// <returns>True if successful, false otherwise with an error message.</returns>
-        internal bool AddBoundary(string name, out Boundary boundary, ref string error)
+        internal bool AddBoundary(string name, out Boundary boundary, out CommandError error)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
                 boundary = null;
-                error = "The name of a boundary must be set.";
+                error = new CommandError("The name of a boundary must be set.");
                 return false;
             }
 
             if (HasChildWithName(name))
             {
                 boundary = null;
-                error = "The name already exists in this boundary!";
+                error = new CommandError("The name already exists in this boundary!");
                 return false;
             }
             _Boundaries.Add((boundary = new Boundary(name, this)));
+            error = null;
             return true;
         }
 
@@ -251,11 +253,11 @@ namespace XTMF2
         /// <param name="block">The resulting block</param>
         /// <param name="error">An error message if the operation fails.</param>
         /// <returns>True if successful, false otherwise with an error message.</returns>
-        internal bool AddCommentBlock(string documentation, Rectangle position, out CommentBlock block, ref string error)
+        internal bool AddCommentBlock(string documentation, Rectangle position, out CommentBlock block, out CommandError error)
         {
             block = null;
             var _block = new CommentBlock(documentation, position);
-            if (!AddCommentBlock(_block, ref error))
+            if (!AddCommentBlock(_block, out error))
             {
                 return false;
             }
@@ -263,17 +265,18 @@ namespace XTMF2
             return true;
         }
 
-        internal bool AddCommentBlock(CommentBlock block, ref string error)
+        internal bool AddCommentBlock(CommentBlock block, out CommandError error)
         {
             if (block is null)
             {
                 throw new ArgumentNullException(nameof(block));
             }
+            error = null;
             lock (_WriteLock)
             {
                 if (_CommentBlocks.Contains(block))
                 {
-                    error = "The documentation block already belongs to the boundary!";
+                    error = new CommandError("The documentation block already belongs to the boundary!");
                     return false;
                 }
                 _CommentBlocks.Add(block);
@@ -281,7 +284,7 @@ namespace XTMF2
             }
         }
 
-        internal bool RemoveCommentBlock(CommentBlock block, ref string error)
+        internal bool RemoveCommentBlock(CommentBlock block, out CommandError error)
         {
             if (block is null)
             {
@@ -291,10 +294,11 @@ namespace XTMF2
             {
                 if (!_CommentBlocks.Remove(block))
                 {
-                    error = "Unable to remove the documentation block from the boundary.";
+                    error = new CommandError("Unable to remove the documentation block from the boundary.");
                     return false;
                 }
             }
+            error = null;
             return true;
         }
 
@@ -350,35 +354,38 @@ namespace XTMF2
         /// <param name="boundary"></param>
         /// <param name="error"></param>
         /// <returns></returns>
-        internal bool AddBoundary(Boundary boundary, ref string error)
+        internal bool AddBoundary(Boundary boundary, out CommandError error)
         {
             if (_Boundaries.Contains(boundary))
             {
-                error = "The name already exists in this boundary!";
+                error = new CommandError("The name already exists in this boundary!");
                 return false;
             }
             _Boundaries.Add(boundary);
+            error = null;
             return true;
         }
 
-        internal bool RemoveBoundary(Boundary boundary, ref string error)
+        internal bool RemoveBoundary(Boundary boundary, out CommandError error)
         {
             if (!_Boundaries.Remove(boundary))
             {
-                error = "Unable to find boundary to remove it!";
+                error = new CommandError("Unable to find boundary to remove it!");
                 return false;
             }
+            error = null;
             return true;
         }
 
-        internal bool AddStart(Start start, ref string e)
-        {
+        internal bool AddStart(Start start, out CommandError error)
+        { 
             if (_Starts.Contains(start))
             {
-                e = "The start already exists in the boundary!";
+                error = new CommandError("The start already exists in the boundary!");
                 return false;
             }
             _Starts.Add(start);
+            error = null;
             return true;
         }
 
@@ -445,14 +452,15 @@ namespace XTMF2
             }
         }
 
-        internal bool AddNode(Node node, ref string e)
+        internal bool AddNode(Node node, out CommandError e)
         {
             if (_Modules.Contains(node))
             {
-                e = "The node already exists in the boundary!";
+                e = new CommandError("The node already exists in the boundary!");
                 return false;
             }
             _Modules.Add(node);
+            e = null;
             return true;
         }
 
@@ -502,13 +510,14 @@ namespace XTMF2
             }
         }
 
-        internal bool RemoveNode(Node node, ref string error)
+        internal bool RemoveNode(Node node, out CommandError error)
         {
             if (!_Modules.Remove(node))
             {
-                error = "Unable to find node in the boundary!";
+                error = new CommandError("Unable to find node in the boundary!");
                 return false;
             }
+            error = null;
             return true;
         }
 
@@ -519,7 +528,7 @@ namespace XTMF2
         /// <param name="link">The returning link</param>
         /// <param name="e">An error message if one occurs</param>
         /// <returns>True if it was added again, false otherwise with message.</returns>
-        internal bool AddLink(Link link, ref string e)
+        internal bool AddLink(Link link, out CommandError e)
         {
             if (link == null)
             {
@@ -527,15 +536,16 @@ namespace XTMF2
             }
             if (link.Origin.ContainedWithin != this)
             {
-                e = "This link is was not contained within this boundary!";
+                e = new CommandError("This link is was not contained within this boundary!");
                 return false;
             }
             if (_Links.Contains(link))
             {
-                e = "This link is already contained within this boundary!";
+                e = new CommandError("This link is already contained within this boundary!");
                 return false;
             }
             _Links.Add(link);
+            e = null;
             return true;
         }
 
@@ -663,7 +673,7 @@ namespace XTMF2
             return true;
         }
 
-        internal bool AddLink(Node origin, NodeHook originHook, Node destination, out Link link, ref string error)
+        internal bool AddLink(Node origin, NodeHook originHook, Node destination, out Link link, out CommandError error)
         {
             switch (originHook.Cardinality)
             {
@@ -692,7 +702,7 @@ namespace XTMF2
                                 OriginHook = originHook
                             };
                         }
-                        if (!((MultiLink)link).AddDestination(destination, ref error))
+                        if (!((MultiLink)link).AddDestination(destination, out error))
                         {
                             link = null;
                             return false;
@@ -705,10 +715,11 @@ namespace XTMF2
                     }
                     break;
             }
+            error = null;
             return true;
         }
 
-        internal bool AddLink(Node origin, NodeHook originHook, Node destination, Link link, ref string error)
+        internal bool AddLink(Node origin, NodeHook originHook, Node destination, Link link, out CommandError error)
         {
             switch (originHook.Cardinality)
             {
@@ -723,7 +734,7 @@ namespace XTMF2
                         {
                             link = previous;
                         }
-                        if (!((MultiLink)link).AddDestination(destination, ref error))
+                        if (!((MultiLink)link).AddDestination(destination, out error))
                         {
                             return false;
                         }
@@ -735,55 +746,60 @@ namespace XTMF2
                     }
                     break;
             }
+            error = null;
             return true;
         }
 
-        internal bool RemoveLink(Link link, ref string e)
+        internal bool RemoveLink(Link link, out CommandError error)
         {
             if (!_Links.Remove(link))
             {
-                e = "Unable to find the link to remove from the boundary!";
+                error = new CommandError("Unable to find the link to remove from the boundary!");
                 return false;
             }
+            error = null;
             return true;
         }
 
-        public bool SetName(string name, ref string error)
+        internal bool SetName(string name, out CommandError error)
         {
             if (String.IsNullOrWhiteSpace(name))
             {
-                error = "A name cannot be whitespace.";
+                error = new CommandError("A name cannot be whitespace.");
                 return false;
             }
             var withName = Parent?.HasChildWithName(name);
             if (withName == true)
             {
-                error = $"There already exists another boundary with the name {name} in the parent boundary!";
+                error = new CommandError($"There already exists another boundary with the name {name} in the parent boundary!");
                 return false;
             }
             Name = name;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            error = null;
             return true;
         }
 
-        public bool SetDescription(string description, ref string error)
+        internal bool SetDescription(string description, out CommandError error)
         {
+            error = null;
             Description = description;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Description)));
             return true;
         }
 
-        internal bool RemoveStart(Start start, ref string error)
+        internal bool RemoveStart(Start start, out CommandError error)
         {
             if (!_Starts.Remove(start))
             {
-                error = "Unable to find a the given start!";
+                error = new CommandError("Unable to find a the given start!");
                 return false;
             }
+            error = null;
             return true;
         }
 
-        internal bool AddStart(ModelSystemSession session, string startName, out Start start, ref string error)
+        internal bool AddStart(ModelSystemSession session, string startName, out Start start, out CommandError error)
         {
             start = null;
             // ensure the name is unique between starting points
@@ -791,12 +807,13 @@ namespace XTMF2
             {
                 if (ms.Name.Equals(startName, StringComparison.OrdinalIgnoreCase))
                 {
-                    error = "There already exists a start with the same name!";
+                    error = new CommandError("There already exists a start with the same name!");
                     return false;
                 }
             }
             start = new Start(session, startName, this, null, new Rectangle(0, 0, 0, 0));
             _Starts.Add(start);
+            error = null;
             return true;
         }
 
@@ -808,31 +825,34 @@ namespace XTMF2
         /// <param name="start"></param>
         /// <param name="error"></param>
         /// <returns></returns>
-        internal bool AddStart(ModelSystemSession session, string startName, Start start, ref string error)
+        internal bool AddStart(ModelSystemSession session, string startName, Start start, out CommandError error)
         {
             // ensure the name is unique between starting points
             foreach (var ms in _Starts)
             {
                 if (ms.Name.Equals(startName, StringComparison.OrdinalIgnoreCase))
                 {
-                    error = "There already exists a start with the same name!";
+                    error = new CommandError("There already exists a start with the same name!");
                     return false;
                 }
             }
             _Starts.Add(start);
+            error = null;
             return true;
         }
 
-        internal bool AddNode(ModelSystemSession session, string name, Type type, out Node node, ref string error)
+        internal bool AddNode(ModelSystemSession session, string name, Type type, out Node node, out CommandError error)
         {
             node = Node.Create(session, name, type, this);
             _Modules.Add(node);
+            error = null;
             return true;
         }
 
-        internal bool AddNode(ModelSystemSession session, string name, Type type, Node node, ref string error)
+        internal bool AddNode(ModelSystemSession session, string name, Type type, Node node, out CommandError error)
         {
             _Modules.Add(node);
+            error = null;
             return true;
         }
     }

--- a/src/XTMF2/ModelSystemConstruct/Link.cs
+++ b/src/XTMF2/ModelSystemConstruct/Link.cs
@@ -188,10 +188,11 @@ namespace XTMF2
 
         internal abstract bool Construct(ref string error);
 
-        internal bool SetDisabled(ModelSystemSession modelSystemSession, bool disabled)
+        internal bool SetDisabled(ModelSystemSession modelSystemSession, bool disabled, out CommandError error)
         {
             IsDisabled = disabled;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDisabled)));
+            error = null;
             return true;
         }
 

--- a/src/XTMF2/ModelSystemConstruct/MultiLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/MultiLink.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Text.Json;
 using System.Collections.ObjectModel;
 using System.Linq;
+using XTMF2.Editing;
 
 namespace XTMF2.ModelSystemConstruct
 {
@@ -42,9 +43,10 @@ namespace XTMF2.ModelSystemConstruct
         public ReadOnlyObservableCollection<Node> Destinations =>
             new ReadOnlyObservableCollection<Node>(_Destinations);
 
-        internal bool AddDestination(Node destination, ref string error)
+        internal bool AddDestination(Node destination, out CommandError error)
         {
             _Destinations.Add(destination);
+            error = null;
             return true;
         }
 

--- a/src/XTMF2/ModelSystemConstruct/SingleLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/SingleLink.cs
@@ -28,10 +28,11 @@ namespace XTMF2.ModelSystemConstruct
     public sealed class SingleLink : Link
     {
         public Node Destination { get; internal set; }
-        public bool SetDestination(ModelSystemSession session, Node destination, ref string error)
+        public bool SetDestination(ModelSystemSession session, Node destination, out CommandError error)
         {
             Destination = destination;
             Notify(nameof(Destination));
+            error = null;
             return true;
         }
 

--- a/src/XTMF2/ModelSystemHeader.cs
+++ b/src/XTMF2/ModelSystemHeader.cs
@@ -50,7 +50,7 @@ namespace XTMF2
             Description = description;
         }
 
-        public bool SetName(string name, ref string error)
+        public bool SetName(string name, out CommandError error)
         {
             try
             {
@@ -61,19 +61,21 @@ namespace XTMF2
                 }
                 Name = name;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+                error = null;
                 return true;
             }
             catch(IOException e)
             {
-                error = e.Message;
+                error = new CommandError(e.Message);
                 return false;
             }
         }
 
-        public bool SetDescription(ProjectSession session, string description, ref string error)
+        public bool SetDescription(ProjectSession session, string description, out CommandError error)
         {
             Description = description;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Description)));
+            error = null;
             return true;
         }
 

--- a/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestBoundaries.cs
@@ -31,17 +31,17 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, ref error), "Created a second boundary with the same name!");
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out error), error?.Message);
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, out error), "Created a second boundary with the same name!");
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
                 Assert.AreSame(subB, ms.GlobalBoundary.Boundaries[0]);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, ref error), "Created a second boundary with the same name after redo!");
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, out error), "Created a second boundary with the same name after redo!");
             });
         }
 
@@ -51,9 +51,8 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddBoundaryWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsFalse(mSession.AddBoundary(unauthorizedUser, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
+                Assert.IsFalse(mSession.AddBoundary(unauthorizedUser, ms.GlobalBoundary, "UniqueName", out Boundary subB, out var error), error?.Message);
             });
         }
 
@@ -63,11 +62,10 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddBoundaryNullParent", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    mSession.AddBoundary(user, null, "UniqueName", out Boundary subB, ref error);
+                    mSession.AddBoundary(user, null, "UniqueName", out Boundary subB, out var error);
                 });
             });
         }
@@ -78,11 +76,10 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddBoundaryNullUser", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    mSession.AddBoundary(null, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error);
+                    mSession.AddBoundary(null, ms.GlobalBoundary, "UniqueName", out Boundary subB, out var error);
                 });
             });
         }
@@ -93,25 +90,24 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, ref error), "Created a second boundary with the same name!");
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out var error), error?.Message);
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, out error), "Created a second boundary with the same name!");
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
                 Assert.AreSame(subB, ms.GlobalBoundary.Boundaries[0]);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, ref error), "Created a second boundary with the same name after redo!");
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, out error), "Created a second boundary with the same name after redo!");
 
                 // Now test removing the boundary explicitly
-                Assert.IsTrue(mSession.RemoveBoundary(user, ms.GlobalBoundary, subB, ref error), error);
+                Assert.IsTrue(mSession.RemoveBoundary(user, ms.GlobalBoundary, subB, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
                 Assert.AreSame(subB, ms.GlobalBoundary.Boundaries[0]);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
             });
         }
@@ -122,21 +118,21 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, ref error), "Created a second boundary with the same name!");
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out error), error?.Message);
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail1, out error), "Created a second boundary with the same name!");
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
                 Assert.AreSame(subB, ms.GlobalBoundary.Boundaries[0]);
-                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, ref error), "Created a second boundary with the same name after redo!");
+                Assert.IsFalse(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary fail2, out error), "Created a second boundary with the same name after redo!");
 
                 // Now test removing the boundary explicitly
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsFalse(mSession.RemoveBoundary(unauthorizedUser, ms.GlobalBoundary, subB, ref error), error);
+                Assert.IsFalse(mSession.RemoveBoundary(unauthorizedUser, ms.GlobalBoundary, subB, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
             });
         }
@@ -147,15 +143,14 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out var error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
 
                 // Now test removing the boundary explicitly
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    mSession.RemoveBoundary(user, ms.GlobalBoundary, null, ref error);
+                    mSession.RemoveBoundary(user, ms.GlobalBoundary, null, out error);
                 });
             });
         }
@@ -166,15 +161,14 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out var error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
 
                 // Now test removing the boundary explicitly
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    mSession.RemoveBoundary(user, null, subB, ref error);
+                    mSession.RemoveBoundary(user, null, subB, out error);
                 });
             });
         }
@@ -185,15 +179,15 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "UniqueName", out Boundary subB, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Boundaries.Count);
 
                 // Now test removing the boundary explicitly
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    mSession.RemoveBoundary(null, ms.GlobalBoundary, subB, ref error);
+                    mSession.RemoveBoundary(null, ms.GlobalBoundary, subB, out error);
                 });
             });
         }
@@ -204,15 +198,15 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveBoundary", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Boundaries.Count);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "SubB", out Boundary subB, ref error), error);
-                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "SubC", out Boundary subC, ref error), error);
-                Assert.IsTrue(mSession.AddBoundary(user, subC, "SubCA", out Boundary subCA, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "SubB", out Boundary subB, out error), error?.Message);
+                Assert.IsTrue(mSession.AddBoundary(user, ms.GlobalBoundary, "SubC", out Boundary subC, out error), error?.Message);
+                Assert.IsTrue(mSession.AddBoundary(user, subC, "SubCA", out Boundary subCA, out error), error?.Message);
                 Assert.AreEqual(2, ms.GlobalBoundary.Boundaries.Count);
                 Assert.AreEqual(1, subC.Boundaries.Count);
 
-                Assert.IsFalse(mSession.RemoveBoundary(user, ms.GlobalBoundary, subCA, ref error), "Successfully removed a boundary from a grandparent isntead of failing!");
+                Assert.IsFalse(mSession.RemoveBoundary(user, ms.GlobalBoundary, subCA, out error), "Successfully removed a boundary from a grandparent isntead of failing!");
             });
         }
         [TestMethod]
@@ -220,23 +214,23 @@ namespace XTMF2.UnitTests.Editing
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
                     var newBoundaryName = "NewBoundaryName";
                     var oldName = ms.GlobalBoundary.Name;
-                    Assert.IsTrue(msSession.SetBoundaryName(localUser, ms.GlobalBoundary, newBoundaryName, ref error), error);
+                    Assert.IsTrue(msSession.SetBoundaryName(localUser, ms.GlobalBoundary, newBoundaryName, out error), error?.Message);
                     Assert.AreEqual(newBoundaryName, ms.GlobalBoundary.Name);
-                    Assert.IsTrue(msSession.Undo(localUser, ref error), error);
+                    Assert.IsTrue(msSession.Undo(localUser, out error), error?.Message);
                     Assert.AreEqual(oldName, ms.GlobalBoundary.Name);
-                    Assert.IsTrue(msSession.Redo(localUser, ref error), error);
+                    Assert.IsTrue(msSession.Redo(localUser, out error), error?.Message);
                     Assert.AreEqual(newBoundaryName, ms.GlobalBoundary.Name);
                 }), "Unable to get a model system editing session!");
             }), "Unable to create project");
@@ -247,18 +241,18 @@ namespace XTMF2.UnitTests.Editing
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             (var localUser, var hacker) = TestHelper.GetTestUsers(runtime);
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
                     var newBoundaryName = "NewBoundaryName";
-                    Assert.IsFalse(msSession.SetBoundaryName(hacker, ms.GlobalBoundary, newBoundaryName, ref error), error);
+                    Assert.IsFalse(msSession.SetBoundaryName(hacker, ms.GlobalBoundary, newBoundaryName, out error), error?.Message);
                 }), "Unable to get a model system editing session!");
             }), "Unable to create project");
         }
@@ -268,23 +262,23 @@ namespace XTMF2.UnitTests.Editing
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
                     var newBoundaryDescription = "NewBoundaryDescription";
                     var oldName = ms.GlobalBoundary.Description;
-                    Assert.IsTrue(msSession.SetBoundaryDescription(localUser, ms.GlobalBoundary, newBoundaryDescription, ref error), error);
+                    Assert.IsTrue(msSession.SetBoundaryDescription(localUser, ms.GlobalBoundary, newBoundaryDescription, out error), error?.Message);
                     Assert.AreEqual(newBoundaryDescription, ms.GlobalBoundary.Description);
-                    Assert.IsTrue(msSession.Undo(localUser, ref error), error);
+                    Assert.IsTrue(msSession.Undo(localUser, out error), error?.Message);
                     Assert.AreEqual(oldName, ms.GlobalBoundary.Description);
-                    Assert.IsTrue(msSession.Redo(localUser, ref error), error);
+                    Assert.IsTrue(msSession.Redo(localUser, out error), error?.Message);
                     Assert.AreEqual(newBoundaryDescription, ms.GlobalBoundary.Description);
                 }), "Unable to get a model system editing session");
             }), "Unable to create project");
@@ -295,19 +289,19 @@ namespace XTMF2.UnitTests.Editing
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             (var localUser, var unauthorizedUser) = TestHelper.GetTestUsers(runtime);
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                Assert.IsTrue(session.CreateNewModelSystem(localUser, "TestMS", out var modelSystem, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                 {
                     var ms = msSession.ModelSystem;
                     var newBoundaryDescription = "NewBoundaryDescription";
                     var oldName = ms.GlobalBoundary.Description;
-                    Assert.IsFalse(msSession.SetBoundaryDescription(unauthorizedUser, ms.GlobalBoundary, newBoundaryDescription, ref error), error);
+                    Assert.IsFalse(msSession.SetBoundaryDescription(unauthorizedUser, ms.GlobalBoundary, newBoundaryDescription, out error), error?.Message);
                 }), "Unable to get a model system editing session");
             }), "Unable to create project");
         }
@@ -317,37 +311,37 @@ namespace XTMF2.UnitTests.Editing
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             const string projectName = "Test";
             const string modelSystemName = "TestMS";
-            controller.DeleteProject(localUser, projectName, ref error);
+            controller.DeleteProject(localUser, projectName, out error);
             var newBoundaryDescription = "NewBoundaryDescription";
             var newBoundaryName = "NewBoundaryName";
             // first pass
             {
-                Assert.IsTrue(controller.CreateNewProject(localUser, projectName, out ProjectSession session, ref error).UsingIf(session, () =>
+                Assert.IsTrue(controller.CreateNewProject(localUser, projectName, out ProjectSession session, out error).UsingIf(session, () =>
                 {
                     var project = session.Project;
-                    Assert.IsTrue(session.CreateNewModelSystem(localUser, modelSystemName, out var modelSystem, ref error), error);
-                    Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                    Assert.IsTrue(session.CreateNewModelSystem(localUser, modelSystemName, out var modelSystem, out error), error?.Message);
+                    Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                         {
                             var ms = msSession.ModelSystem;
-                            Assert.IsTrue(msSession.SetBoundaryName(localUser, ms.GlobalBoundary, newBoundaryName, ref error), error);
-                            Assert.IsTrue(msSession.SetBoundaryDescription(localUser, ms.GlobalBoundary, newBoundaryDescription, ref error), error);
-                            Assert.IsTrue(msSession.Save(ref error), error);
-                            Assert.IsTrue(session.Save(ref error), error);
-                        }), error);
+                            Assert.IsTrue(msSession.SetBoundaryName(localUser, ms.GlobalBoundary, newBoundaryName, out error), error?.Message);
+                            Assert.IsTrue(msSession.SetBoundaryDescription(localUser, ms.GlobalBoundary, newBoundaryDescription, out error), error?.Message);
+                            Assert.IsTrue(msSession.Save(out error), error?.Message);
+                            Assert.IsTrue(session.Save(out error), error?.Message);
+                        }), error?.Message);
 
                 }), "Unable to create project");
             }
             // second pass
             {
-                Assert.IsTrue(controller.GetProject(localUser, projectName, out var project, ref error));
-                Assert.IsTrue(controller.GetProjectSession(localUser, project, out var session, ref error).UsingIf(session, () =>
+                Assert.IsTrue(controller.GetProject(localUser, projectName, out var project, out error));
+                Assert.IsTrue(controller.GetProjectSession(localUser, project, out var session, out error).UsingIf(session, () =>
                 {
-                    Assert.IsTrue(session.GetModelSystemHeader(localUser, modelSystemName, out var modelSystem, ref error), error);
-                    Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, ref error).UsingIf(msSession, () =>
+                    Assert.IsTrue(session.GetModelSystemHeader(localUser, modelSystemName, out var modelSystem, out error), error?.Message);
+                    Assert.IsTrue(session.EditModelSystem(localUser, modelSystem, out var msSession, out error).UsingIf(msSession, () =>
                     {
                         var ms = msSession.ModelSystem;
                         Assert.AreEqual(newBoundaryName, ms.GlobalBoundary.Name);

--- a/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
@@ -18,6 +18,7 @@
 */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using XTMF2.Editing;
 using XTMF2.ModelSystemConstruct;
 
 namespace XTMF2.UnitTests.Editing
@@ -30,13 +31,13 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestCreatingCommentBlock", (user, pSession, mSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = mSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(mSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(mSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
@@ -48,13 +49,13 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestCreatingCommentBlockWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = mSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsFalse(mSession.AddCommentBlock(unauthorizedUser, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsFalse(mSession.AddCommentBlock(unauthorizedUser, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(0, comBlocks.Count);
             });
         }
@@ -66,15 +67,15 @@ namespace XTMF2.UnitTests.Editing
             var location = new Rectangle(100, 100);
             TestHelper.RunInModelSystemContext("TestCommentBlockPersistence", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
-                Assert.IsTrue(msSession.Save(ref error), error);
+                Assert.IsTrue(msSession.Save(out error), error?.Message);
             }, (user, pSession, msSession)=>
             {
                 var ms = msSession.ModelSystem;
@@ -90,17 +91,17 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestRemovingCommentBlock", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
-                Assert.IsTrue(msSession.RemoveCommentBlock(user, ms.GlobalBoundary, block, ref error), error);
+                Assert.IsTrue(msSession.RemoveCommentBlock(user, ms.GlobalBoundary, block, out error), error?.Message);
                 Assert.AreEqual(0, comBlocks.Count);
             });
         }
@@ -110,17 +111,17 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestRemovingCommentBlockWithBadUser", (user, unauthorizedUser, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
-                Assert.IsFalse(msSession.RemoveCommentBlock(unauthorizedUser, ms.GlobalBoundary, block, ref error), error);
+                Assert.IsFalse(msSession.RemoveCommentBlock(unauthorizedUser, ms.GlobalBoundary, block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
             });
         }
@@ -130,19 +131,19 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestCreatingCommentBlockUndoRedo", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlock = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlock.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlock.Count);
                 Assert.AreEqual(comment, comBlock[0].Comment);
                 Assert.AreEqual(location, comBlock[0].Location);
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, comBlock.Count);
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, comBlock.Count);
                 Assert.AreEqual(comment, comBlock[0].Comment);
             });
@@ -153,23 +154,23 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestRemovingCommentBlockUndoRedo", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
-                Assert.IsTrue(msSession.RemoveCommentBlock(user, ms.GlobalBoundary, block, ref error), error);
+                Assert.IsTrue(msSession.RemoveCommentBlock(user, ms.GlobalBoundary, block, out error), error?.Message);
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
                 Assert.AreEqual(location, comBlocks[0].Location);
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, comBlocks.Count);
             });
         }
@@ -179,21 +180,21 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestChangingCommentBlockText", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var newComment = "New comment";
                 var location = new Rectangle(100, 100);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
-                Assert.IsTrue(msSession.SetCommentBlockText(user, block, newComment, ref error), error);
+                Assert.IsTrue(msSession.SetCommentBlockText(user, block, newComment, out error), error?.Message);
                 Assert.AreEqual(newComment, block.Comment, "The comment block's text was not set!");
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(comment, block.Comment, "The comment block's text was not undone!");
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(newComment, block.Comment);
             });
         }
@@ -203,21 +204,21 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("TestChangingCommentBlockPosition", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var comment = "My Comment";
                 var location = new Rectangle(100, 100);
                 var newLocation = new Rectangle(100, 200);
                 var comBlocks = ms.GlobalBoundary.CommentBlocks;
                 Assert.AreEqual(0, comBlocks.Count);
-                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, ref error), error);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
                 Assert.AreEqual(1, comBlocks.Count);
                 Assert.AreEqual(comment, comBlocks[0].Comment);
-                Assert.IsTrue(msSession.SetCommentBlockLocation(user, block, newLocation, ref error), error);
+                Assert.IsTrue(msSession.SetCommentBlockLocation(user, block, newLocation, out error), error?.Message);
                 Assert.AreEqual(newLocation, block.Location, "The comment block's location was not set!");
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(location, block.Location, "The comment block's location was not undone!");
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(newLocation, block.Location);
             });
         }

--- a/tests/XTMF2.UnitTests/Editing/TestLinks.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestLinks.cs
@@ -23,7 +23,7 @@ using System.Threading;
 using XTMF2.UnitTests.Modules;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.RuntimeModules;
-
+using XTMF2.Editing;
 
 namespace XTMF2.UnitTests.Editing
 {
@@ -36,19 +36,19 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoAddLink", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
-                    out var parameter, ref error), error);
+                    out var parameter, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
-                    out var module, ref error), error);
+                    out var module, out error), error?.Message);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 Assert.AreSame(link, ms.GlobalBoundary.Links[0]);
             });
@@ -60,24 +60,24 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveLink", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
-                    out var parameter, ref error), error);
+                    out var parameter, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
-                    out var module, ref error), error);
+                    out var module, out error), error?.Message);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 Assert.AreSame(link, ms.GlobalBoundary.Links[0]);
 
                 // now remove the link explicitly
-                Assert.IsTrue(mSession.RemoveLink(user, link, ref error), error);
+                Assert.IsTrue(mSession.RemoveLink(user, link, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
             });
         }
@@ -88,24 +88,24 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveLinkWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
-                    out var parameter, ref error), error);
+                    out var parameter, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
-                    out var module, ref error), error);
+                    out var module, out error), error?.Message);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 Assert.AreSame(link, ms.GlobalBoundary.Links[0]);
 
                 // now remove the link explicitly
-                Assert.IsFalse(mSession.RemoveLink(unauthorizedUser, link, ref error), error);
+                Assert.IsFalse(mSession.RemoveLink(unauthorizedUser, link, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
             });
         }
@@ -116,29 +116,29 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoRemoveLink", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<string>),
-                    out var parameter, ref error), error);
+                    out var parameter, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(SimpleParameterModule),
-                    out var module, ref error), error);
+                    out var module, out error), error?.Message);
                 Assert.AreEqual(2, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, module, module.Hooks[0], parameter, out var link, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 Assert.AreSame(link, ms.GlobalBoundary.Links[0]);
 
                 // now remove the link explicitly
-                Assert.IsTrue(mSession.RemoveLink(user, link, ref error), error);
+                Assert.IsTrue(mSession.RemoveLink(user, link, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 Assert.AreSame(link, ms.GlobalBoundary.Links[0]);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Links.Count);
             });
         }
@@ -154,14 +154,14 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss1, ref error));
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss2, ref error));
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss1, out var link1, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss1, out error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss2, out error));
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss1, out var link1, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
                 // This should not create a new link but move the previous one
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss2, out var link2, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss2, out var link2, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
             });
         }
@@ -172,24 +172,24 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveLinkToBoundariesThatWereRemoved", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 var global = ms.GlobalBoundary;
                 // Setup the delete
-                Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, out error), error?.Message);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
-                    out var tricky, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], tricky, out var link, ref error), error);
+                    out var tricky, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], tricky, out var link, out error), error?.Message);
                 Assert.AreEqual(1, global.Starts.Count);
                 Assert.AreEqual(1, global.Links.Count);
                 Assert.AreEqual(1, toRemove.Modules.Count);
 
                 // Now remove the boundary and check to make sure the number of links is cleaned up
-                Assert.IsTrue(mSession.RemoveBoundary(user, global, toRemove, ref error), error);
+                Assert.IsTrue(mSession.RemoveBoundary(user, global, toRemove, out error), error?.Message);
                 Assert.AreEqual(0, global.Links.Count, "We did not remove the link during the remove boundary!");
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, global.Links.Count, "The link was not restored after the undo on the remove boundary!");
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, global.Links.Count, "We did not remove the link again doing the redo of the remove boundary!");
             });
         }
@@ -200,28 +200,28 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveMultiLinkToBoundariesThatWereRemoved", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 var global = ms.GlobalBoundary;
                 // Setup the delete
-                Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, ref error), error);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
+                Assert.IsTrue(mSession.AddBoundary(user, global, "ToRemove", out var toRemove, out error), error?.Message);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, global, "Execute", typeof(Execute),
-                    out var execute, ref error), error);
+                    out var execute, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, toRemove, "Tricky", typeof(IgnoreResult<string>),
-                    out var tricky, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"), tricky, out var link2, ref error), error);
+                    out var tricky, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"), tricky, out var link2, out error), error?.Message);
                 Assert.AreEqual(1, global.Starts.Count);
                 Assert.AreEqual(1, global.Modules.Count);
                 Assert.AreEqual(2, global.Links.Count);
                 Assert.AreEqual(1, toRemove.Modules.Count);
 
                 // Now remove the boundary and check to make sure the number of links is cleaned up
-                Assert.IsTrue(mSession.RemoveBoundary(user, global, toRemove, ref error), error);
+                Assert.IsTrue(mSession.RemoveBoundary(user, global, toRemove, out error), error?.Message);
                 Assert.AreEqual(0, ((MultiLink)global.Links.First(l => l.Origin == execute)).Destinations.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, ((MultiLink)global.Links.First(l => l.Origin == execute)).Destinations.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, ((MultiLink)global.Links.First(l => l.Origin == execute)).Destinations.Count);
             });
         }
@@ -232,27 +232,27 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveSingleDestinationInMultiLink", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 var global = ms.GlobalBoundary;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, global, "Execute", typeof(Execute),
-                    out var execute, ref error), error);
+                    out var execute, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, global, "Tricky", typeof(IgnoreResult<string>),
-                    out var ignore, ref error), error);
+                    out var ignore, out error), error?.Message);
 
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, out error), error?.Message);
                 // Create 2 links from the execute into the ignore
                 Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"),
-                    execute, out var linkI1, ref error), error);
+                    execute, out var linkI1, out error), error?.Message);
                 Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"),
-                    execute, out var _, ref error), error);
+                    execute, out var _, out error), error?.Message);
 
                 Assert.AreEqual(2, ((MultiLink)linkI1).Destinations.Count);
-                Assert.IsTrue(mSession.RemoveLinkDestination(user, linkI1, 0, ref error), error);
+                Assert.IsTrue(mSession.RemoveLinkDestination(user, linkI1, 0, out error), error?.Message);
                 Assert.AreEqual(1, ((MultiLink)linkI1).Destinations.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(2, ((MultiLink)linkI1).Destinations.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ((MultiLink)linkI1).Destinations.Count);
             });
         }
@@ -263,23 +263,23 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveSingleDestinationInMultiLinkWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 var global = ms.GlobalBoundary;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, global, "Start", out var start, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, global, "Execute", typeof(Execute),
-                    out var execute, ref error), error);
+                    out var execute, out error), error?.Message);
                 Assert.IsTrue(mSession.AddNode(user, global, "Tricky", typeof(IgnoreResult<string>),
-                    out var ignore, ref error), error);
+                    out var ignore, out error), error?.Message);
 
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], execute, out var link, out error), error?.Message);
                 // Create 2 links from the execute into the ignore
                 Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"),
-                    execute, out var linkI1, ref error), error);
+                    execute, out var linkI1, out error), error?.Message);
                 Assert.IsTrue(mSession.AddLink(user, execute, TestHelper.GetHook(execute.Hooks, "To Execute"),
-                    execute, out var _, ref error), error);
+                    execute, out var _, out error), error?.Message);
 
                 Assert.AreEqual(2, ((MultiLink)linkI1).Destinations.Count);
-                Assert.IsFalse(mSession.RemoveLinkDestination(unauthorizedUser, linkI1, 0, ref error), error);
+                Assert.IsFalse(mSession.RemoveLinkDestination(unauthorizedUser, linkI1, 0, out error), error?.Message);
                 Assert.AreEqual(2, ((MultiLink)linkI1).Destinations.Count, "An unauthorized user was able to change the number of destinations.");
             });
         }
@@ -291,19 +291,19 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = msSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var startLink, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var startLink, out error), error?.Message);
 
                 Assert.IsFalse(startLink.IsDisabled, "The link initialized as disabled!");
-                Assert.IsTrue(msSession.SetLinkDisabled(user, startLink, true, ref error), error);
+                Assert.IsTrue(msSession.SetLinkDisabled(user, startLink, true, out error), error?.Message);
                 Assert.IsTrue(startLink.IsDisabled, "The link initialized as disabled!");
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.IsFalse(startLink.IsDisabled);
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.IsTrue(startLink.IsDisabled);
             }, (user, pSession, mSession) =>
             {
@@ -324,15 +324,15 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = msSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error), error);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var startLink, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error), error?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var startLink, out error), error?.Message);
 
                 Assert.IsFalse(startLink.IsDisabled, "The link initialized as disabled!");
-                Assert.IsFalse(msSession.SetLinkDisabled(unauthorizedUser, startLink, true, ref error), error);
+                Assert.IsFalse(msSession.SetLinkDisabled(unauthorizedUser, startLink, true, out error), error?.Message);
             });
         }
 
@@ -341,20 +341,20 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("DisabledLinkRunValidationFailure", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var requiredLink, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, ref error2), error2);
-                Assert.IsTrue(msSession.SetLinkDisabled(user, requiredLink, true, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var requiredLink, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetLinkDisabled(user, requiredLink, true, out error2), error2?.Message);
                 TestHelper.CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using (SemaphoreSlim sim = new SemaphoreSlim(0))
                     {
@@ -365,10 +365,10 @@ namespace XTMF2.UnitTests.Editing
                         };
                         runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                         {
-                            error = e + "\r\n" + stack;
+                            error = new CommandError(e + "\r\n" + stack);
                             sim.Release();
                         };
-                        Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, ref error), error);
+                        Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, out error), error?.Message);
                         // give the models system some time to complete
                         if (!sim.Wait(2000))
                         {

--- a/tests/XTMF2.UnitTests/Editing/TestNode.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestNode.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using XTMF2.UnitTests.Modules;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.RuntimeModules;
+using XTMF2.Editing;
 
 namespace XTMF2.UnitTests.Editing
 {
@@ -34,9 +35,9 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddStart", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
             });
         }
@@ -47,9 +48,9 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddStartWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsFalse(mSession.AddModelSystemStart(unauthorizedUser, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsFalse(mSession.AddModelSystemStart(unauthorizedUser, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
             });
         }
@@ -60,13 +61,13 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoAddStart", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreSame(Start, ms.GlobalBoundary.Starts[0]);
             });
@@ -78,18 +79,18 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoAddStart", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreSame(Start, ms.GlobalBoundary.Starts[0]);
 
                 //now test explicitly removing the start
-                Assert.IsTrue(mSession.RemoveStart(user, Start, ref error), error);
+                Assert.IsTrue(mSession.RemoveStart(user, Start, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
             });
         }
@@ -100,18 +101,18 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveStartWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreSame(Start, ms.GlobalBoundary.Starts[0]);
 
                 //now test explicitly removing the start
-                Assert.IsFalse(mSession.RemoveStart(unauthorizedUser, Start, ref error), error);
+                Assert.IsFalse(mSession.RemoveStart(unauthorizedUser, Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
             });
         }
@@ -122,22 +123,22 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoAddStart", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, ref error), error);
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out var Start, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreSame(Start, ms.GlobalBoundary.Starts[0]);
 
                 //now test explicitly removing the start
-                Assert.IsTrue(mSession.RemoveStart(user, Start, ref error), error);
+                Assert.IsTrue(mSession.RemoveStart(user, Start, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Starts.Count);
             });
         }
@@ -148,10 +149,10 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
             });
         }
@@ -162,10 +163,10 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("AddNodeWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsFalse(mSession.AddNode(unauthorizedUser, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
             });
         }
@@ -176,14 +177,14 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoAddNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreSame(mss, ms.GlobalBoundary.Modules[0]);
             });
@@ -195,19 +196,19 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreSame(mss, ms.GlobalBoundary.Modules[0]);
 
                 // now remove node explicitly
-                Assert.IsTrue(mSession.RemoveNode(user, mss, ref error), error);
+                Assert.IsTrue(mSession.RemoveNode(user, mss, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
             });
         }
@@ -218,19 +219,19 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("RemoveNodeWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreSame(mss, ms.GlobalBoundary.Modules[0]);
 
                 // now remove node explicitly
-                Assert.IsFalse(mSession.RemoveNode(unauthorizedUser, mss, ref error), error);
+                Assert.IsFalse(mSession.RemoveNode(unauthorizedUser, mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
             });
         }
@@ -241,23 +242,23 @@ namespace XTMF2.UnitTests.Editing
             TestHelper.RunInModelSystemContext("UndoRemoveNode", (user, pSession, mSession) =>
             {
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
                 Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Start", typeof(BasicParameter<int>),
-                    out var mss, ref error), error);
+                    out var mss, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreSame(mss, ms.GlobalBoundary.Modules[0]);
 
                 // now remove node explicitly
-                Assert.IsTrue(mSession.RemoveNode(user, mss, ref error), error);
+                Assert.IsTrue(mSession.RemoveNode(user, mss, out error), error?.Message);
                 Assert.AreEqual(0, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
             });
         }
 
@@ -269,11 +270,11 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("AddNodeWithParameterGeneration", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNotNull(children, "The child parameters of the node were returned as a null!");
                 Assert.AreEqual(1, children.Count);
@@ -305,11 +306,11 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("AddNodeWithParameterGenerationWithBadUser", (user, unauthorizedUser, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsFalse(msSession.AddNodeGenerateParameters(unauthorizedUser, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNull(children, "The child parameters of the node were returned as a null!");
                 var modules = gBound.Modules;
@@ -328,11 +329,11 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("AddNodeWithParameterGenerationUndo", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNotNull(children, "The child parameters of the node were returned as a null!");
                 Assert.AreEqual(1, children.Count);
@@ -340,10 +341,10 @@ namespace XTMF2.UnitTests.Editing
                 var links = gBound.Links;
                 Assert.AreEqual(2, modules.Count, "It seems that the child parameter was not contained in the global boundary.");
                 Assert.AreEqual(1, links.Count, "We did not have a link!");
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(0, modules.Count, "After undoing it seems that a module has survived.");
                 Assert.AreEqual(0, links.Count, "The link was not removed on undo.");
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(2, modules.Count, "After redoing it seems that a module was not restored.");
                 Assert.AreEqual(1, links.Count, "The link was not re-added on redo.");
             });
@@ -357,11 +358,11 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("RemoveNodeWithParameterGeneration", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNotNull(children, "The child parameters of the node were returned as a null!");
                 Assert.AreEqual(1, children.Count);
@@ -383,14 +384,14 @@ namespace XTMF2.UnitTests.Editing
                 }
                 Assert.IsTrue(found, "We did not find the automatically created parameter module!");
 
-                Assert.IsTrue(msSession.RemoveNodeGenerateParameters(user, node, ref error), error);
+                Assert.IsTrue(msSession.RemoveNodeGenerateParameters(user, node, out error), error?.Message);
 
                 // Make sure that both modules were deleted
                 Assert.AreEqual(0, modules.Count, "Both modules were not removed.");
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(2, modules.Count, "Both modules were not re-added.");
 
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(0, modules.Count, "Both modules were not removed again.");
             });
         }
@@ -403,11 +404,11 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("RemoveNodeWithParameterGenerationWithBadUser", (user, unauthorizedUser, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNotNull(children, "The child parameters of the node were returned as a null!");
                 Assert.AreEqual(1, children.Count);
@@ -428,7 +429,7 @@ namespace XTMF2.UnitTests.Editing
                     }
                 }
                 Assert.IsTrue(found, "We did not find the automatically created parameter module!");
-                Assert.IsFalse(msSession.RemoveNodeGenerateParameters(unauthorizedUser, node, ref error), error);
+                Assert.IsFalse(msSession.RemoveNodeGenerateParameters(unauthorizedUser, node, out error), error?.Message);
                 Assert.AreEqual(2, modules.Count, "The number of modules changed after an invalid user invoked RemoveNodeGenerateParameters.");
                 Assert.AreEqual(1, links.Count, "The number of links changed after an invalid user invoked RemoveNodeGenerateParameters!");
             });
@@ -444,13 +445,13 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("RemoveNodeWithParameterGenerationWithBadUser", (user, unauthorizedUser, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
                 var gBound = ms.GlobalBoundary;
                 Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node, out var children, ref error), error);
+                    typeof(SimpleParameterModule), out var node, out var children, out error), error?.Message);
                 Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Test",
-                    typeof(SimpleParameterModule), out var node2, ref error), error);
+                    typeof(SimpleParameterModule), out var node2, out error), error?.Message);
                 // Test to make sure that there was a second module also added.
                 Assert.IsNotNull(children, "The child parameters of the node were returned as a null!");
                 Assert.AreEqual(1, children.Count);
@@ -458,15 +459,15 @@ namespace XTMF2.UnitTests.Editing
                 var links = gBound.Links;
                 Assert.AreEqual(1, links.Count);
                 Assert.AreEqual(3, modules.Count);
-                Assert.IsTrue(msSession.AddLink(user, node2, node2.Hooks[0], children[0], out var node2Link, ref error), error);
+                Assert.IsTrue(msSession.AddLink(user, node2, node2.Hooks[0], children[0], out var node2Link, out error), error?.Message);
                 Assert.AreEqual(2, links.Count, "The second link was not added");
-                Assert.IsTrue(msSession.RemoveNodeGenerateParameters(user, node, ref error), error);
+                Assert.IsTrue(msSession.RemoveNodeGenerateParameters(user, node, out error), error?.Message);
                 Assert.AreEqual(1, links.Count);
                 Assert.AreEqual(2, modules.Count);
-                Assert.IsTrue(msSession.Undo(user, ref error), error);
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(2, links.Count);
                 Assert.AreEqual(3, modules.Count);
-                Assert.IsTrue(msSession.Redo(user, ref error), error);
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(1, links.Count);
                 Assert.AreEqual(2, modules.Count);
             });
@@ -477,14 +478,14 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("SetParameterValue", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
                 var parameterValue = "Hello World Parameter";
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, parameterValue, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, parameterValue, out error2), error2?.Message);
                 Assert.AreEqual(parameterValue, basicParameter.ParameterValue, "The value of the parameter was not set correctly."); 
             });
         }
@@ -494,18 +495,18 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("SetParameterValueWithBadUser", (user, unauthorizedUser, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
                 var parameterValue = "Hello World Parameter";
                 var badParameterValue = "HackerValue";
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, parameterValue, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, parameterValue, out error2), error2?.Message);
                 Assert.AreEqual(parameterValue, basicParameter.ParameterValue, "The value of the parameter was not set correctly.");
 
-                Assert.IsFalse(msSession.SetParameterValue(unauthorizedUser, basicParameter, badParameterValue, ref error2), error2);
+                Assert.IsFalse(msSession.SetParameterValue(unauthorizedUser, basicParameter, badParameterValue, out error2), error2?.Message);
                 Assert.AreEqual(parameterValue, basicParameter.ParameterValue, "The unauthorized user changed the parameter's value!");
             });
         }
@@ -517,15 +518,15 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
                 Assert.AreEqual("MyMSS", mss.Name);
                 Assert.IsFalse(mss.IsDisabled, "The node started out as disabled!");
-                Assert.IsTrue(mSession.SetNodeDisabled(user, mss, true, ref error), error);
+                Assert.IsTrue(mSession.SetNodeDisabled(user, mss, true, out error), error?.Message);
                 Assert.IsTrue(mss.IsDisabled, "The node was not disabled!");
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.IsFalse(mss.IsDisabled, "The node was not re-enabled when undoing the disable instruction!");
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.IsTrue(mss.IsDisabled, "The node was not disabled during the redo!");
             }, (user, pSession, mSession) =>
             {
@@ -544,11 +545,11 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
                 Assert.AreEqual("MyMSS", mss.Name);
                 Assert.IsFalse(mss.IsDisabled, "The node started out as disabled!");
-                Assert.IsFalse(mSession.SetNodeDisabled(unauthroizedUser, mss, true, ref error), error);
+                Assert.IsFalse(mSession.SetNodeDisabled(unauthroizedUser, mss, true, out error), error?.Message);
             });
         }
 
@@ -557,20 +558,21 @@ namespace XTMF2.UnitTests.Editing
         {
             TestHelper.RunInModelSystemContext("DisabledNodeRunValidationFailure", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetNodeDisabled(user, basicParameter, true, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetNodeDisabled(user, basicParameter, true, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, out error2), error2?.Message);
                 TestHelper.CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
+                    string errorString = null;
                     bool success = false;
                     using (SemaphoreSlim sim = new SemaphoreSlim(0))
                     {
@@ -581,10 +583,10 @@ namespace XTMF2.UnitTests.Editing
                         };
                         runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                         {
-                            error = e + "\r\n" + stack;
+                            errorString = e + "\r\n" + stack;
                             sim.Release();
                         };
-                        Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, ref error), error);
+                        Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, out error), error?.Message);
                         // give the models system some time to complete
                         if (!sim.Wait(2000))
                         {
@@ -604,15 +606,15 @@ namespace XTMF2.UnitTests.Editing
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
                 Assert.AreEqual("MyMSS", mss.Name);
                 var oldLocation = mss.Location;
-                Assert.IsTrue(mSession.SetNodeLocation(user, mss, newLocation, ref error), error);
+                Assert.IsTrue(mSession.SetNodeLocation(user, mss, newLocation, out error), error?.Message);
                 Assert.AreEqual(newLocation, mss.Location);
-                Assert.IsTrue(mSession.Undo(user, ref error), error);
+                Assert.IsTrue(mSession.Undo(user, out error), error?.Message);
                 Assert.AreEqual(oldLocation, mss.Location);
-                Assert.IsTrue(mSession.Redo(user, ref error), error);
+                Assert.IsTrue(mSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(newLocation, mss.Location);
                 
             }, (user, pSession, mSession) =>

--- a/tests/XTMF2.UnitTests/TestHelper.cs
+++ b/tests/XTMF2.UnitTests/TestHelper.cs
@@ -44,18 +44,18 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string projectName = "TestProject";
             // clear out the user if possible
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
                     toExecute(user, projectSession);
-                }), error);
+                }), error?.Message);
             }
             finally
             {
@@ -75,24 +75,24 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string projectName = "TestProject";
             // clear out the user if possible
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
                     toExecuteFirst(user, projectSession);
-                }), error);
+                }), error?.Message);
 
-                Assert.IsTrue(projectController.GetProject(user, projectName, out var project, ref error), error);
-                Assert.IsTrue(projectController.GetProjectSession(user, project, out projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.GetProject(user, projectName, out var project, out error), error?.Message);
+                Assert.IsTrue(projectController.GetProjectSession(user, project, out projectSession, out error).UsingIf(projectSession, () =>
                 {
                     toExecuteSecond(user, projectSession);
-                }), error);
+                }), error?.Message);
             }
             finally
             {
@@ -111,18 +111,18 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string projectName = "TestProject";
             // clear out the user if possible
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
                     toExecute(runtime, user, projectSession);
-                }), error);
+                }), error?.Message);
             }
             finally
             {
@@ -141,21 +141,21 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string unauthorizedUserName = userName + "Hacker";
             string projectName = "TestProject";
             // clear out the user if possible
             userController.Delete(userName);
             userController.Delete(unauthorizedUserName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
-            Assert.IsTrue(userController.CreateNew(unauthorizedUserName, false, out var unauthorizedUser, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(unauthorizedUserName, false, out var unauthorizedUser, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
                     toExecute(user, unauthorizedUser, projectSession);
-                }), error);
+                }), error?.Message);
             }
             finally
             {
@@ -174,23 +174,23 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string projectName = "TestProject";
             string modelSystemName = "ModelSystem1";
             // clear out the user if possible
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(modelSystemSession, () =>
                     {
                         toExecute(user, projectSession, modelSystemSession);
-                    }), error);
-                }), error);
+                    }), error?.Message);
+                }), error?.Message);
             }
             finally
             {
@@ -209,7 +209,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string unauthorizedUserName = name + "Hacker";
             string projectName = "TestProject";
@@ -217,18 +217,18 @@ namespace XTMF2.UnitTests
             // clear out the user if possible
             userController.Delete(userName);
             userController.Delete(unauthorizedUserName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
-            Assert.IsTrue(userController.CreateNew(unauthorizedUserName, false, out var unauthorizedUser, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(unauthorizedUserName, false, out var unauthorizedUser, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(modelSystemSession, () =>
                     {
                         toExecute(user, unauthorizedUser, projectSession, modelSystemSession);
-                    }), error);
-                }), error);
+                    }), error?.Message);
+                }), error?.Message);
             }
             finally
             {
@@ -262,13 +262,13 @@ namespace XTMF2.UnitTests
             {
                 throw new ArgumentNullException(nameof(runtime));
             }
-            string error = null;
+            CommandError error = null;
             var localUser = runtime.UserController.GetUserByName("local");
             var userController = runtime.UserController;
             var unauthroizedUser = userController.GetUserByName("Hacker");
             if (unauthroizedUser is null)
             {
-                Assert.IsTrue(userController.CreateNew("Hacker", false, out unauthroizedUser, ref error), error);
+                Assert.IsTrue(userController.CreateNew("Hacker", false, out unauthroizedUser, out error), error?.Message);
             }
             else
             {
@@ -283,7 +283,7 @@ namespace XTMF2.UnitTests
                     var copyOfProjects = projects.ToList();
                     foreach (var project in copyOfProjects)
                     {
-                        Assert.IsTrue(projectController.DeleteProject(localUser, project, ref error), error);
+                        Assert.IsTrue(projectController.DeleteProject(localUser, project, out error), error?.Message);
                     }
                 }
             }
@@ -304,26 +304,26 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             string userName = name + "TempUser";
             string projectName = "TestProject";
             string modelSystemName = "ModelSystem1";
             // clear out the user if possible
             userController.Delete(userName);
 
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
             try
             {
-                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var projectSession, out error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
+                    Assert.IsTrue(projectSession.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(modelSystemSession, () =>
                     {
                         toExecuteFirst(user, projectSession, modelSystemSession);
-                        Assert.IsTrue(modelSystemSession.Save(ref error), error);
-                    }), error);
-                    Assert.IsTrue(projectSession.Save(ref error));
-                }), error);
+                        Assert.IsTrue(modelSystemSession.Save(out error), error?.Message);
+                    }), error?.Message);
+                    Assert.IsTrue(projectSession.Save(out error));
+                }), error?.Message);
 
                 runtime.Shutdown();
 
@@ -331,15 +331,15 @@ namespace XTMF2.UnitTests
                 userController = runtime.UserController;
                 projectController = runtime.ProjectController;
                 user = userController.GetUserByName(userName);
-                Assert.IsTrue(projectController.GetProject(userName, projectName, out var project, ref error), error);
-                Assert.IsTrue(projectController.GetProjectSession(user, project, out projectSession, ref error).UsingIf(projectSession, () =>
+                Assert.IsTrue(projectController.GetProject(userName, projectName, out var project, out error), error?.Message);
+                Assert.IsTrue(projectController.GetProjectSession(user, project, out projectSession, out error).UsingIf(projectSession, () =>
                 {
-                    Assert.IsTrue(projectSession.GetModelSystemHeader(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(modelSystemSession, () =>
+                    Assert.IsTrue(projectSession.GetModelSystemHeader(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                    Assert.IsTrue(projectSession.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(modelSystemSession, () =>
                     {
                         toExecuteSecond(user, projectSession, modelSystemSession);
-                    }), error);
-                }), error);
+                    }), error?.Message);
+                }), error?.Message);
             }
             finally
             {
@@ -354,14 +354,14 @@ namespace XTMF2.UnitTests
         /// <param name="runLogic"></param>
         public static void CreateRunClient(bool startClientProcess, Action<HostBus> runLogic)
         {
-            string error = null;
             var id = startClientProcess ? Guid.NewGuid().ToString() : "123";
             var xtmfClientFileName = typeof(XTMF2.Client.Program).GetTypeInfo().Assembly.Location;
             var testFileName = Path.GetFullPath(typeof(TestHelper).GetTypeInfo().Assembly.Location);
             Process client = null;
             try
             {
-                Assert.IsTrue(XTMF2.Bus.CreateStreams.CreateNewNamedPipeHost(id, out var hostStream, ref error,
+                string errorString = null;
+                Assert.IsTrue(XTMF2.Bus.CreateStreams.CreateNewNamedPipeHost(id, out var hostStream, ref errorString,
                 () =>
                 {
                     if (startClientProcess)
@@ -395,7 +395,7 @@ namespace XTMF2.UnitTests
                     Assert.IsNotNull(client, "The client was never created!");
                 }
                 runLogic(new HostBus(hostStream, true));
-            }), error);
+            }), errorString);
             }
             finally
             {
@@ -449,7 +449,7 @@ namespace XTMF2.UnitTests
                         File.Delete(path);
                     }
                 }
-                catch(IOException)
+                catch (IOException)
                 {
 
                 }
@@ -484,7 +484,7 @@ namespace XTMF2.UnitTests
             {
                 a();
             }
-            catch(Exception e2)
+            catch (Exception e2)
             {
                 e = e2;
                 return false;

--- a/tests/XTMF2.UnitTests/TestModelSystem.cs
+++ b/tests/XTMF2.UnitTests/TestModelSystem.cs
@@ -26,6 +26,7 @@ using XTMF2.ModelSystemConstruct;
 using XTMF2.UnitTests.Modules;
 using XTMF2.RuntimeModules;
 using static XTMF2.UnitTests.TestHelper;
+using XTMF2.Editing;
 
 namespace XTMF2.UnitTests
 {
@@ -38,29 +39,29 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName = "NewUser";
             const string projectName = "TestProject";
             const string modelSystemName = "ModelSystem1";
             // clear out the user if possible
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, out error).UsingIf(session, () =>
             {
-                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                Assert.IsTrue(session.Save(ref error));
-            }), error);
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                Assert.IsTrue(session.Save(out error));
+            }), error?.Message);
             runtime.Shutdown();
             runtime = XTMFRuntime.CreateRuntime();
             userController = runtime.UserController;
             projectController = runtime.ProjectController;
             user = userController.GetUserByName(userName);
-            Assert.IsTrue(projectController.GetProjectSession(user, user.AvailableProjects[0], out session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(projectController.GetProjectSession(user, user.AvailableProjects[0], out session, out error).UsingIf(session, () =>
              {
                  var modelSystems = session.ModelSystems;
                  Assert.AreEqual(1, modelSystems.Count);
                  Assert.AreEqual(modelSystemName, modelSystems[0].Name);
-             }), error);
+             }), error?.Message);
             //cleanup
             userController.Delete(user);
         }
@@ -70,10 +71,10 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("GetModelSystemSession", (user, pSession, mSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var globalBoundary = mSession.ModelSystem.GlobalBoundary;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, globalBoundary, "Start", out Start start, ref error), error);
-                Assert.IsFalse(mSession.AddModelSystemStart(user, globalBoundary, "Start", out Start start_, ref error));
+                Assert.IsTrue(mSession.AddModelSystemStart(user, globalBoundary, "Start", out Start start, out error), error?.Message);
+                Assert.IsFalse(mSession.AddModelSystemStart(user, globalBoundary, "Start", out Start start_, out error));
             });
         }
 
@@ -83,7 +84,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName = "NewUser";
             const string userName2 = "NewUser2";
             const string projectName = "TestProject";
@@ -91,24 +92,24 @@ namespace XTMF2.UnitTests
             // clear out the user if possible
             userController.Delete(userName);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, out error).UsingIf(session, () =>
             {
                 // share the session with the second user
-                Assert.IsTrue(session.ShareWith(user, user2, ref error), error);
+                Assert.IsTrue(session.ShareWith(user, user2, out error), error?.Message);
                 // create a new model system for both users to try to edit
-                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(
                     modelSystemSession, () =>
                     {
-                        Assert.IsTrue(session.EditModelSystem(user2, modelSystemHeader, out var modelSystemSession2, ref error).UsingIf(modelSystemSession2, () =>
+                        Assert.IsTrue(session.EditModelSystem(user2, modelSystemHeader, out var modelSystemSession2, out error).UsingIf(modelSystemSession2, () =>
                         {
                             Assert.AreSame(modelSystemSession, modelSystemSession2);
-                        }), error);
-                    }), error);
-                Assert.IsTrue(session.Save(ref error));
-            }), error);
+                        }), error?.Message);
+                    }), error?.Message);
+                Assert.IsTrue(session.Save(out error));
+            }), error?.Message);
 
             //cleanup
             userController.Delete(user);
@@ -120,7 +121,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName = "NewUser";
             const string userName2 = "NewUser2";
             const string projectName = "TestProject";
@@ -128,25 +129,25 @@ namespace XTMF2.UnitTests
             // clear out the user if possible
             userController.Delete(userName);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user, projectName, out var session, out error).UsingIf(session, () =>
             {
                 // share the session with the second user
-                Assert.IsTrue(session.ShareWith(user, user2, ref error), error);
+                Assert.IsTrue(session.ShareWith(user, user2, out error), error?.Message);
                 // create a new model system for both users to try to edit
-                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, ref error), error);
-                Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, ref error).UsingIf(
+                Assert.IsTrue(session.CreateNewModelSystem(user, modelSystemName, out var modelSystemHeader, out error), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(user, modelSystemHeader, out var modelSystemSession, out error).UsingIf(
                     modelSystemSession, () =>
                     {
 
-                    }), error);
-                Assert.IsTrue(session.EditModelSystem(user2, modelSystemHeader, out var modelSystemSession2, ref error).UsingIf(modelSystemSession2, () =>
+                    }), error?.Message);
+                Assert.IsTrue(session.EditModelSystem(user2, modelSystemHeader, out var modelSystemSession2, out error).UsingIf(modelSystemSession2, () =>
                 {
                     Assert.AreNotSame(modelSystemSession, modelSystemSession2);
-                }), error);
-                Assert.IsTrue(session.Save(ref error));
-            }), error);
+                }), error?.Message);
+                Assert.IsTrue(session.Save(out error));
+            }), error?.Message);
 
             //cleanup
             userController.Delete(user);
@@ -159,17 +160,17 @@ namespace XTMF2.UnitTests
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
 
             }, (user, pSession, mSession) =>
             {
                 // after shutdown
                 var ms = mSession.ModelSystem;
-                string error = null;
+                CommandError error = null;
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 // we shouldn't be able to add another start with the same name in the same boundary
-                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
             });
         }
 
@@ -180,8 +181,8 @@ namespace XTMF2.UnitTests
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
                 Assert.AreEqual("MyMSS", mss.Name);
             }, (user, pSession, mSession) =>
             {
@@ -198,18 +199,18 @@ namespace XTMF2.UnitTests
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
                 Assert.AreEqual("MyMSS", mss.Name);
             }, (user, pSession, mSession) =>
             {
                 // after shutdown
-                string error = null;
+                CommandError error = null;
                 var ms = mSession.ModelSystem;
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
-                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
             });
         }
 
@@ -220,20 +221,20 @@ namespace XTMF2.UnitTests
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, ref error));
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss, out var link, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "MyMSS", typeof(SimpleTestModule), out var mss, out error));
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, start, start.Hooks[0], mss, out var link, out error), error?.Message);
                 Assert.AreEqual("MyMSS", mss.Name);
             }, (user, pSession, mSession) =>
             {
                 // after shutdown
-                string error = null;
+                CommandError error = null;
                 var ms = mSession.ModelSystem;
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreEqual(1, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(1, ms.GlobalBoundary.Links.Count);
-                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
             });
         }
 
@@ -244,28 +245,28 @@ namespace XTMF2.UnitTests
             {
                 // initialization
                 var ms = mSession.ModelSystem;
-                string error = null;
-                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                CommandError error = null;
+                Assert.IsTrue(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
 
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, ref error));
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
-                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, out error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, out error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, out error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, out error));
+                Assert.IsTrue(mSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, out error));
 
 
-                Assert.IsTrue(mSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore1, out var link1, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore2, out var link2, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore3, out var link3, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore1, out var link1, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore2, out var link2, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore3, out var link3, out error), error?.Message);
 
                 Assert.AreNotSame(link, link1);
                 Assert.AreSame(link1, link2);
                 Assert.AreSame(link1, link3);
 
-                Assert.IsTrue(mSession.AddLink(user, ignore1, GetHook(ignore1.Hooks, "To Ignore"), hello, out var toSame1, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, ignore2, GetHook(ignore2.Hooks, "To Ignore"), hello, out var toSame2, ref error), error);
-                Assert.IsTrue(mSession.AddLink(user, ignore3, GetHook(ignore3.Hooks, "To Ignore"), hello, out var toSame3, ref error), error);
+                Assert.IsTrue(mSession.AddLink(user, ignore1, GetHook(ignore1.Hooks, "To Ignore"), hello, out var toSame1, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, ignore2, GetHook(ignore2.Hooks, "To Ignore"), hello, out var toSame2, out error), error?.Message);
+                Assert.IsTrue(mSession.AddLink(user, ignore3, GetHook(ignore3.Hooks, "To Ignore"), hello, out var toSame3, out error), error?.Message);
 
                 Assert.AreNotSame(toSame1, toSame2);
                 Assert.AreNotSame(toSame1, toSame3);
@@ -275,12 +276,12 @@ namespace XTMF2.UnitTests
             }, (user, pSession, mSession) =>
             {
                 // after shutdown
-                string error = null;
+                CommandError error = null;
                 var ms = mSession.ModelSystem;
                 Assert.AreEqual(1, ms.GlobalBoundary.Starts.Count);
                 Assert.AreEqual(5, ms.GlobalBoundary.Modules.Count);
                 Assert.AreEqual(5, ms.GlobalBoundary.Links.Count);
-                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                Assert.IsFalse(mSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
             });
         }
 
@@ -289,12 +290,12 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ExportModelSystem", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -306,16 +307,16 @@ namespace XTMF2.UnitTests
                     using (session)
                     {
                         var ms = session.ModelSystem;
-                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, ref error), error);
-                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, ref error), error);
-                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, ref error), error);
-                        Assert.IsTrue(session.Save(ref error), error);
-                        Assert.IsFalse(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error),
+                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, out error), error?.Message);
+                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, out error), error?.Message);
+                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, out error), error?.Message);
+                        Assert.IsTrue(session.Save(out error), error?.Message);
+                        Assert.IsFalse(project.ExportModelSystem(user, msHeader, tempFile.FullName, out error),
                             "The model system was exported while there was still a session using it!");
                         tempFile.Refresh();
                         Assert.IsFalse(tempFile.Exists, "The model system was exported even through it reported to fail to export!");
                     }
-                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, out error), error?.Message);
                     tempFile.Refresh();
                     Assert.IsTrue(tempFile.Exists, "The exported model system does not exist even after confirming that it was exported successfully!");
                 }
@@ -335,14 +336,14 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ExportModelSystem", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
                 var msDescription = "Description of the model system";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(msHeader.SetDescription(project, msDescription, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(msHeader.SetDescription(project, msDescription, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 FileInfo tempFile = new FileInfo(Path.GetTempFileName());
                 var fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(XTMF2.XTMFRuntime).Assembly.Location);
                 try
@@ -355,12 +356,12 @@ namespace XTMF2.UnitTests
                     using (session)
                     {
                         var ms = session.ModelSystem;
-                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, ref error), error);
-                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, ref error), error);
-                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, ref error), error);
-                        Assert.IsTrue(session.Save(ref error), error);
+                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, out error), error?.Message);
+                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, out error), error?.Message);
+                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, out error), error?.Message);
+                        Assert.IsTrue(session.Save(out error), error?.Message);
                     }
-                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, out error), error?.Message);
                     tempFile.Refresh();
                     Assert.IsTrue(tempFile.Exists, "The exported model system does not exist even after confirming that it was exported successfully!");
 
@@ -461,15 +462,15 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ImportModelSystem", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(msHeader.SetDescription(project, description, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -481,13 +482,13 @@ namespace XTMF2.UnitTests
                     using (session)
                     {
                         var ms = session.ModelSystem;
-                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, ref error), error);
-                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, ref error), error);
-                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, ref error), error);
-                        Assert.IsTrue(session.Save(ref error), error);
+                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, out error), error?.Message);
+                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, out error), error?.Message);
+                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, out error), error?.Message);
+                        Assert.IsTrue(session.Save(out error), error?.Message);
                     }
-                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
-                    Assert.IsTrue(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error), error);
+                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, out error), error?.Message);
+                    Assert.IsTrue(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, out error), error?.Message);
                     Assert.IsNotNull(importedHeader, "The model system header was not set!");
                     Assert.AreEqual(importedName, importedHeader.Name, "The name of the imported model system was not the same as what was specified.");
                     Assert.AreEqual(description, importedHeader.Description);
@@ -508,15 +509,15 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ImportModelSystemBadUser", (user, unauthorizedUser, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
                 var startName = "MyStart";
                 var nodeName = "MyNode";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(msHeader.SetDescription(project, description, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -528,13 +529,13 @@ namespace XTMF2.UnitTests
                     using (session)
                     {
                         var ms = session.ModelSystem;
-                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, ref error), error);
-                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, ref error), error);
-                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, ref error), error);
-                        Assert.IsTrue(session.Save(ref error), error);
+                        Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, out error), error?.Message);
+                        Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, out error), error?.Message);
+                        Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, out error), error?.Message);
+                        Assert.IsTrue(session.Save(out error), error?.Message);
                     }
-                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, ref error), error);
-                    Assert.IsFalse(project.ImportModelSystem(unauthorizedUser, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
+                    Assert.IsTrue(project.ExportModelSystem(user, msHeader, tempFile.FullName, out error), error?.Message);
+                    Assert.IsFalse(project.ImportModelSystem(unauthorizedUser, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, out error),
                         "An unauthorized user was able to import a model system!");
                     Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
                 }
@@ -554,15 +555,15 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ImportModelSystemBadFilePath", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(msHeader.SetDescription(project, description, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 var tempFile = new FileInfo(Path.GetTempFileName());
-                Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
+                Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, out error),
                     "An unauthorized user was able to import a model system!");
                 Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
             });
@@ -573,13 +574,13 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("ImportModelSystemBadFilePath", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var importedName = "MSImported";
                 var description = "A test model system.";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(msHeader.SetDescription(project, description, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 var tempDir = new FileInfo(Path.GetTempFileName());
                 tempDir.Delete();
@@ -588,7 +589,7 @@ namespace XTMF2.UnitTests
                 {
                     Directory.CreateDirectory(tempDir.FullName);
                     ZipFile.CreateFromDirectory(tempDir.FullName, tempFile.FullName);
-                    Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, ref error),
+                    Assert.IsFalse(project.ImportModelSystem(user, tempFile.FullName, importedName, out ModelSystemHeader importedHeader, out error),
                         "An unauthorized user was able to import a model system!");
                     Assert.IsNull(importedHeader, "A model system header was created even though the import model system operation failed!");
                 }
@@ -612,12 +613,12 @@ namespace XTMF2.UnitTests
         {
             RunInProjectContext("RenameModelSystem", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var newName = "NewMSName";
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
                 Assert.AreEqual(msName, msHeader.Name);
-                Assert.IsTrue(project.RenameModelSystem(user, msHeader, newName, ref error), error);
+                Assert.IsTrue(project.RenameModelSystem(user, msHeader, newName, out error), error?.Message);
                 Assert.AreEqual(newName, msHeader.Name);
             });
         }

--- a/tests/XTMF2.UnitTests/TestProjects.cs
+++ b/tests/XTMF2.UnitTests/TestProjects.cs
@@ -33,18 +33,18 @@ namespace XTMF2.UnitTests
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             // delete the project in case it has survived.
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
                 Assert.AreEqual("Test", project.Name);
                 Assert.AreEqual(localUser, project.Owner);
             }), "Unable to create project");
-            Assert.IsTrue(controller.DeleteProject(localUser, "Test", ref error));
-            Assert.IsFalse(controller.DeleteProject(localUser, "Test", ref error));
+            Assert.IsTrue(controller.DeleteProject(localUser, "Test", out error));
+            Assert.IsFalse(controller.DeleteProject(localUser, "Test", out error));
         }
 
         [TestMethod]
@@ -52,21 +52,21 @@ namespace XTMF2.UnitTests
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             // delete the project in case it has survived.
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
                 Assert.AreEqual("Test", project.Name);
                 Assert.AreEqual(localUser, project.Owner);
-                Assert.IsFalse(controller.RenameProject(localUser, project, "RenamedTestProject", ref error),
+                Assert.IsFalse(controller.RenameProject(localUser, project, "RenamedTestProject", out error),
                     "RenameProject succeeded even through it was currently being edited!");
             }), "Unable to create project");
-            Assert.IsTrue(controller.GetProject(localUser, "Test", out var project, ref error), error);
-            Assert.IsTrue(controller.RenameProject(localUser, project, "RenamedTestProject", ref error), error);
-            Assert.IsTrue(controller.DeleteProject(localUser, project, ref error), "Failed to cleanup the project.");
+            Assert.IsTrue(controller.GetProject(localUser, "Test", out var project, out error), error?.Message);
+            Assert.IsTrue(controller.RenameProject(localUser, project, "RenamedTestProject", out error), error?.Message);
+            Assert.IsTrue(controller.DeleteProject(localUser, project, out error), "Failed to cleanup the project.");
         }
 
         [TestMethod]
@@ -75,12 +75,12 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
             string projectName = "Test";
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             // delete the project just in case it survived
-            controller.DeleteProject(localUser, projectName, ref error);
+            controller.DeleteProject(localUser, projectName, out error);
             // now create it
-            Assert.IsTrue(controller.CreateNewProject(localUser, projectName, out ProjectSession session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(controller.CreateNewProject(localUser, projectName, out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
                 Assert.AreEqual(projectName, project.Name);
@@ -103,24 +103,24 @@ namespace XTMF2.UnitTests
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             runtime.UserController.Delete("NewUser");
-            Assert.IsTrue(runtime.UserController.CreateNew("NewUser", false, out var newUser, ref error), error);
+            Assert.IsTrue(runtime.UserController.CreateNew("NewUser", false, out var newUser, out error), error?.Message);
             // delete the project in case it has survived.
-            controller.DeleteProject(localUser, "Test", ref error);
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            controller.DeleteProject(localUser, "Test", out error);
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 var project = session.Project;
-                Assert.IsTrue(session.ShareWith(localUser, newUser, ref error), error);
-                Assert.IsTrue(controller.GetProjectSession(newUser, project, out var session2, ref error).UsingIf(session2, () =>
+                Assert.IsTrue(session.ShareWith(localUser, newUser, out error), error?.Message);
+                Assert.IsTrue(controller.GetProjectSession(newUser, project, out var session2, out error).UsingIf(session2, () =>
                 {
                     Assert.AreSame(session, session2);
-                }), error);
+                }), error?.Message);
             }), "Unable to create project");
 
             // cleanup
-            Assert.IsTrue(controller.DeleteProject(localUser, "Test", ref error));
+            Assert.IsTrue(controller.DeleteProject(localUser, "Test", out error));
         }
 
         [TestMethod]
@@ -132,43 +132,43 @@ namespace XTMF2.UnitTests
              */
             var runtime = XTMFRuntime.CreateRuntime();
             var controller = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             var localUser = TestHelper.GetTestUser(runtime);
             runtime.UserController.Delete("NewUser");
-            Assert.IsTrue(runtime.UserController.CreateNew("NewUser", false, out var newUser, ref error), error);
+            Assert.IsTrue(runtime.UserController.CreateNew("NewUser", false, out var newUser, out error), error?.Message);
             // delete the project in case it has survived.
-            controller.DeleteProject(localUser, "Test", ref error);
+            controller.DeleteProject(localUser, "Test", out error);
             Project project = null;
-            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, ref error).UsingIf(session, () =>
+            Assert.IsTrue(controller.CreateNewProject(localUser, "Test", out ProjectSession session, out error).UsingIf(session, () =>
             {
                 project = session.Project;
-                Assert.IsTrue(session.ShareWith(localUser, newUser, ref error), error);
+                Assert.IsTrue(session.ShareWith(localUser, newUser, out error), error?.Message);
 
             }), "Unable to create project");
-            Assert.IsTrue(controller.GetProjectSession(newUser, project, out var session2, ref error).UsingIf(session2, () =>
+            Assert.IsTrue(controller.GetProjectSession(newUser, project, out var session2, out error).UsingIf(session2, () =>
             {
                 Assert.AreNotSame(session, session2);
-            }), error);
+            }), error?.Message);
 
             // cleanup
-            Assert.IsTrue(controller.DeleteProject(localUser, "Test", ref error));
+            Assert.IsTrue(controller.DeleteProject(localUser, "Test", out error));
         }
 
         private static void CreateModelSystem(User user, ProjectSession project, string msName, string description, Action executeBeforeSessionClosed)
         {
-            string error = null;
+            CommandError error = null;
             var startName = "MyStart";
             var nodeName = "MyNode";
-            Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-            Assert.IsTrue(msHeader.SetDescription(project, description, ref error), error);
-            Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error), error);
+            Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+            Assert.IsTrue(msHeader.SetDescription(project, description, out error), error?.Message);
+            Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error), error?.Message);
             using (session)
             {
                 var ms = session.ModelSystem;
-                Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, ref error), error);
-                Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, ref error), error);
-                Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, ref error), error);
-                Assert.IsTrue(session.Save(ref error), error);
+                Assert.IsTrue(session.AddModelSystemStart(user, ms.GlobalBoundary, startName, out var start, out error), error?.Message);
+                Assert.IsTrue(session.AddNode(user, ms.GlobalBoundary, nodeName, typeof(IgnoreResult<string>), out var node, out error), error?.Message);
+                Assert.IsTrue(session.AddLink(user, start, TestHelper.GetHook(start.Hooks, "ToExecute"), node, out var link, out error), error?.Message);
+                Assert.IsTrue(session.Save(out error), error?.Message);
                 if (!(executeBeforeSessionClosed is null))
                 {
                     executeBeforeSessionClosed();
@@ -181,7 +181,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ExportProjectNoModelSystems", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -190,7 +190,7 @@ namespace XTMF2.UnitTests
                     {
                         tempFile.Delete();
                     }
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                 }
                 finally
@@ -209,7 +209,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ExportProjectSingleModelSystem", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var description = "A test model system.";
                 var tempFile = new FileInfo(Path.GetTempFileName());
@@ -222,9 +222,9 @@ namespace XTMF2.UnitTests
                     }
                     CreateModelSystem(user, project, msName, description, () =>
                     {
-                        Assert.IsFalse(project.ExportProject(user, tempFile.FullName, ref error), "We were able to export a project while a model system was being edited!");
+                        Assert.IsFalse(project.ExportProject(user, tempFile.FullName, out error), "We were able to export a project while a model system was being edited!");
                     });
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     tempFile.Refresh();
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                 }
@@ -244,7 +244,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ExportProjectMultipleModelSystems", (user, project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var msName = "MSToExport";
                 var description = "A test model system.";
 
@@ -260,7 +260,7 @@ namespace XTMF2.UnitTests
                     {
                         CreateModelSystem(user, project, msName + i, description + i, null);
                     }
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                 }
                 finally
@@ -279,7 +279,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ImportProjectFileNoModelSystem", (XTMFRuntime runtime, User user, ProjectSession project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -288,11 +288,11 @@ namespace XTMF2.UnitTests
                     {
                         tempFile.Delete();
                     }
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                     var projectController = runtime.ProjectController;
                     Assert.IsTrue(projectController.ImportProjectFile(user, "ImportProjectFileNoModelSystem-Imported", tempFile.FullName,
-                        out var importedSession, ref error), error);
+                        out var importedSession, out error), error?.Message);
                     Assert.IsNotNull(importedSession);
                     using (importedSession)
                     {
@@ -316,7 +316,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ImportProjectFileSingleModelSystem", (XTMFRuntime runtime, User user, ProjectSession project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -326,11 +326,11 @@ namespace XTMF2.UnitTests
                         tempFile.Delete();
                     }
                     CreateModelSystem(user, project, "ModelSystem1", "A single model system", null);
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                     var projectController = runtime.ProjectController;
                     Assert.IsTrue(projectController.ImportProjectFile(user, "ImportProjectFileSingleModelSystem-Imported", tempFile.FullName,
-                        out var importedSession, ref error), error);
+                        out var importedSession, out error), error?.Message);
                     Assert.IsNotNull(importedSession);
                     using (importedSession)
                     {
@@ -354,7 +354,7 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("ImportProjectFileSingleModelSystem", (XTMFRuntime runtime, User user, ProjectSession project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -368,11 +368,11 @@ namespace XTMF2.UnitTests
                     {
                         CreateModelSystem(user, project, "ModelSystem" + i, "One of many model systems", null);
                     }
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                     var projectController = runtime.ProjectController;
                     Assert.IsTrue(projectController.ImportProjectFile(user, "ImportProjectFileSingleModelSystem-Imported", tempFile.FullName,
-                        out var importedSession, ref error), error);
+                        out var importedSession, out error), error?.Message);
                     Assert.IsNotNull(importedSession);
                     using (importedSession)
                     {
@@ -397,7 +397,7 @@ namespace XTMF2.UnitTests
             const string ImportedModelSystemName = "ImportProjectFileNoModelSystemPersist-Imported";
             TestHelper.RunInProjectContext("ImportProjectFileNoModelSystemPersist", (XTMFRuntime runtime, User user, ProjectSession project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var tempFile = new FileInfo(Path.GetTempFileName());
                 try
                 {
@@ -406,12 +406,12 @@ namespace XTMF2.UnitTests
                     {
                         tempFile.Delete();
                     }
-                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, ref error), error);
+                    Assert.IsTrue(project.ExportProject(user, tempFile.FullName, out error), error?.Message);
                     Assert.IsTrue(tempFile.Exists, "The exported file does not exist!");
                     var projectController = runtime.ProjectController;
 
                     Assert.IsTrue(projectController.ImportProjectFile(user, ImportedModelSystemName, tempFile.FullName,
-                        out var importedSession, ref error), error);
+                        out var importedSession, out error), error?.Message);
                     Assert.IsNotNull(importedSession);
                     Assert.IsTrue(user.AvailableProjects.Any(p => p.Name == ImportedModelSystemName), "The imported project was not available to use user.");
                     using (importedSession)
@@ -441,9 +441,9 @@ namespace XTMF2.UnitTests
                 var dir = new DirectoryInfo(Guid.NewGuid().ToString());
                 try
                 {
-                    string error = null;
+                    CommandError error = null;
                     dir.Create();
-                    Assert.IsTrue(project.SetCustomRunDirectory(user, dir.FullName, ref error), error);
+                    Assert.IsTrue(project.SetCustomRunDirectory(user, dir.FullName, out error), error?.Message);
                     Assert.AreEqual(dir.FullName, project.RunsDirectory);
                 }
                 finally
@@ -461,10 +461,10 @@ namespace XTMF2.UnitTests
         {
             TestHelper.RunInProjectContext("SetRunsDirectoryToInvalidPath", (User user, ProjectSession project) =>
             {
-                string error = null;
+                CommandError error = null;
                 var initialDirectory = project.RunsDirectory;
                 const string anInvalidPath = ":?!@#://#%$^&|";
-                Assert.IsFalse(project.SetCustomRunDirectory(user, anInvalidPath, ref error), "An invalid path was able to be set.");
+                Assert.IsFalse(project.SetCustomRunDirectory(user, anInvalidPath, out error), "An invalid path was able to be set.");
                 Assert.AreEqual(initialDirectory, project.RunsDirectory);
             });
         }
@@ -478,12 +478,12 @@ namespace XTMF2.UnitTests
                 DirectoryInfo dir = new DirectoryInfo(newRunDir);
                 try
                 {
-                    string error = null;
+                    CommandError error = null;
                     dir.Create();
                     var initialDirectory = project.RunsDirectory;
-                    Assert.IsTrue(project.SetCustomRunDirectory(user, dir.FullName, ref error), error);
+                    Assert.IsTrue(project.SetCustomRunDirectory(user, dir.FullName, out error), error?.Message);
                     Assert.AreEqual(dir.FullName, project.RunsDirectory);
-                    Assert.IsTrue(project.ResetCustomRunDirectory(user, ref error), error);
+                    Assert.IsTrue(project.ResetCustomRunDirectory(user, out error), error?.Message);
                     Assert.AreEqual(initialDirectory, project.RunsDirectory);
                 }
                 finally
@@ -502,13 +502,13 @@ namespace XTMF2.UnitTests
             TestHelper.RunInProjectContext("RemoveModelSystem", (User user, ProjectSession project) =>
             {
                 const string msName = "RemoveMe";
-                string error = null;
-                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, ref error), error);
-                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, ref error).UsingIf(session, ()=>
+                CommandError error = null;
+                Assert.IsTrue(project.CreateNewModelSystem(user, msName, out var msHeader, out error), error?.Message);
+                Assert.IsTrue(project.EditModelSystem(user, msHeader, out var session, out error).UsingIf(session, ()=>
                 {
-                    Assert.IsFalse(project.RemoveModelSystem(user, msHeader, ref error), "A model system was able to be removed while it was being edited!");
-                }), error);
-                Assert.IsTrue(project.RemoveModelSystem(user, msHeader, ref error), error);
+                    Assert.IsFalse(project.RemoveModelSystem(user, msHeader, out error), "A model system was able to be removed while it was being edited!");
+                }), error?.Message);
+                Assert.IsTrue(project.RemoveModelSystem(user, msHeader, out error), error?.Message);
             });
         }
     }

--- a/tests/XTMF2.UnitTests/TestRun.cs
+++ b/tests/XTMF2.UnitTests/TestRun.cs
@@ -23,6 +23,7 @@ using XTMF2.ModelSystemConstruct;
 using XTMF2.UnitTests.Modules;
 using XTMF2.RuntimeModules;
 using static XTMF2.UnitTests.TestHelper;
+using XTMF2.Editing;
 
 namespace XTMF2.UnitTests
 {
@@ -48,8 +49,8 @@ namespace XTMF2.UnitTests
             {
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(Directory.GetCurrentDirectory(), "CreatingClient"), "Start", out var id, ref error), error);
+                    CommandError error = null;
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(Directory.GetCurrentDirectory(), "CreatingClient"), "Start", out var id, out error), error?.Message);
                 });
             });
         }
@@ -59,16 +60,16 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("RunModelSystemToComplete", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], stm, out var ignoreLink2, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], stm, out var ignoreLink2, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
                     runBus.ClientFinishedModelSystem += (sender, e) =>
@@ -78,10 +79,10 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
@@ -97,19 +98,19 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("ParameterModules", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "SPM", typeof(SimpleParameterModule), out var spm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyParameter", typeof(BasicParameter<string>), out var basicParameter, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, basicParameter, "Hello World Parameter", out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], spm, out var ignoreLink2, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, spm, spm.Hooks[0], basicParameter, out var ignoreLink3, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
                     runBus.ClientFinishedModelSystem += (sender, e) =>
@@ -119,10 +120,10 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
@@ -139,33 +140,33 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("ParameterModules", (user, pSession, msSession) =>
             {
-                string error = null;
+                CommandError error = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, ref error), error);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "FirstStart", out var start, out error), error?.Message);
 
-                Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, out var _, ref error));
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, ref error));
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, ref error));
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, ref error));
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, ref error));
+                Assert.IsTrue(msSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Execute", typeof(Execute), out var mss, out var _, out error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore1", typeof(IgnoreResult<string>), out var ignore1, out error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore2", typeof(IgnoreResult<string>), out var ignore2, out error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Ignore3", typeof(IgnoreResult<string>), out var ignore3, out error));
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Hello World", typeof(SimpleTestModule), out var hello, out error));
                 
 
 
-                Assert.IsTrue(msSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore1, out var link1, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore2, out var link2, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore3, out var link3, ref error), error);
+                Assert.IsTrue(msSession.AddLink(user, start, GetHook(start.Hooks, "ToExecute"), mss, out var link, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore1, out var link1, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore2, out var link2, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, mss, GetHook(mss.Hooks, "To Execute"), ignore3, out var link3, out error), error?.Message);
 
                 Assert.AreNotSame(link, link1);
                 Assert.AreSame(link1, link2);
                 Assert.AreSame(link1, link3);
 
-                Assert.IsTrue(msSession.AddLink(user, ignore1, GetHook(ignore1.Hooks, "To Ignore"), hello, out var toSame1, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, ignore2, GetHook(ignore2.Hooks, "To Ignore"), hello, out var toSame2, ref error), error);
-                Assert.IsTrue(msSession.AddLink(user, ignore3, GetHook(ignore3.Hooks, "To Ignore"), hello, out var toSame3, ref error), error);
+                Assert.IsTrue(msSession.AddLink(user, ignore1, GetHook(ignore1.Hooks, "To Ignore"), hello, out var toSame1, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignore2, GetHook(ignore2.Hooks, "To Ignore"), hello, out var toSame2, out error), error?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignore3, GetHook(ignore3.Hooks, "To Ignore"), hello, out var toSame3, out error), error?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error2 = null;
+                    CommandError error2 = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
 
@@ -176,16 +177,16 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error2 = e + "\r\n" + stack;
+                        error2 = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "FirstStart", out var id, ref error2), error2);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "CreatingClient"), "FirstStart", out var id, out error2), error2?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
                         Assert.Fail("The model system failed to execute in time!");
                     }
-                    Assert.IsTrue(success, "The model system failed to execute to success! " + error2);
+                    Assert.IsTrue(success, "The model system failed to execute to success! " + error2?.Message);
 
                 });
             });
@@ -196,21 +197,21 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("ReportRunProgress", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(ReportFunctionInvocation<string>), out var report, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Message", typeof(BasicParameter<string>), out var message, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], report, out var ignoreLink2, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, report, GetHook(report.Hooks, "To Invoke"), stm, out var ignoreLink3, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, report, GetHook(report.Hooks, "Message"), message, out var ignoreLink4, ref error2), error2);
-                Assert.IsTrue(msSession.SetParameterValue(user, message, "Reporting through XTMF", ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(ReportFunctionInvocation<string>), out var report, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "Message", typeof(BasicParameter<string>), out var message, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], report, out var ignoreLink2, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, report, GetHook(report.Hooks, "To Invoke"), stm, out var ignoreLink3, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, report, GetHook(report.Hooks, "Message"), message, out var ignoreLink4, out error2), error2?.Message);
+                Assert.IsTrue(msSession.SetParameterValue(user, message, "Reporting through XTMF", out error2), error2?.Message);
                 CreateRunClient(true, (clientBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     string reportedStatus = null;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
@@ -222,14 +223,14 @@ namespace XTMF2.UnitTests
                     };
                     clientBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
                     clientBus.ClientReportedStatus += (sender, runId, status) =>
                     {
                         reportedStatus = status;
                     };
-                    Assert.IsTrue(clientBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "ReportRunProgress"), "Start", out var id, ref error), error);
+                    Assert.IsTrue(clientBus.RunModelSystem(msSession, Path.Combine(pSession.RunsDirectory, "ReportRunProgress"), "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
@@ -237,7 +238,7 @@ namespace XTMF2.UnitTests
                     }
                     Assert.IsNotNull(reportedStatus);
                     Assert.AreEqual("Reporting through XTMF", reportedStatus);
-                    Assert.IsTrue(success, "The model system failed to execute to success! " + error);
+                    Assert.IsTrue(success, "The model system failed to execute to success! " + error?.Message);
                 });
             });
         }
@@ -247,16 +248,16 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("RunResultsCompleted", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, ref error2), error2);
-                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], stm, out var ignoreLink2, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "AnIgnore", typeof(IgnoreResult<string>), out var ignoreMSS, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "MyFunction", typeof(SimpleTestModule), out var stm, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], ignoreMSS, out var ignoreLink1, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, ignoreMSS, ignoreMSS.Hooks[0], stm, out var ignoreLink2, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
 
@@ -267,17 +268,17 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
                     var runDirectory = Path.Combine(pSession.RunsDirectory, "RunResultsCompleted");
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
                         Assert.Fail("The model system failed to execute in time!");
                     }
-                    Assert.IsTrue(success, "The model system failed to execute to success! " + error);
+                    Assert.IsTrue(success, "The model system failed to execute to success! " + error?.Message);
 
                     // Check to make sure that the meta-data was stored in the run directory
                     var results = new RunResults(runDirectory);
@@ -296,15 +297,15 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("RunResultsRuntimeError", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
                 Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "RequiresAChild",
-                typeof(FailsAtRuntime), out var node, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, ref error2), error2);
+                typeof(FailsAtRuntime), out var node, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
 
@@ -315,11 +316,11 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
                     var runDirectory = Path.Combine(pSession.RunsDirectory, "RunResultsRuntimeError");
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
@@ -344,15 +345,15 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("RunResultsValidationError", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
                 Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "RequiresAChild",
-                typeof(IgnoreResult<string>), out var node, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, ref error2), error2);
+                typeof(IgnoreResult<string>), out var node, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
 
@@ -363,11 +364,11 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
                     var runDirectory = Path.Combine(pSession.RunsDirectory, "CheckRunModelSystemRunCompleteData");
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {
@@ -392,15 +393,15 @@ namespace XTMF2.UnitTests
         {
             RunInModelSystemContext("RunResultsRuntimeValidationError", (user, pSession, msSession) =>
             {
-                string error2 = null;
+                CommandError error2 = null;
                 var ms = msSession.ModelSystem;
-                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, ref error2), error2);
+                Assert.IsTrue(msSession.AddModelSystemStart(user, ms.GlobalBoundary, "Start", out Start start, out error2), error2?.Message);
                 Assert.IsTrue(msSession.AddNode(user, ms.GlobalBoundary, "RequiresAChild",
-                typeof(FailsAtRuntimeValidation), out var node, ref error2), error2);
-                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, ref error2), error2);
+                typeof(FailsAtRuntimeValidation), out var node, out error2), error2?.Message);
+                Assert.IsTrue(msSession.AddLink(user, start, start.Hooks[0], node, out var link, out error2), error2?.Message);
                 CreateRunClient(true, (runBus) =>
                 {
-                    string error = null;
+                    CommandError error = null;
                     bool success = false;
                     using SemaphoreSlim sim = new SemaphoreSlim(0);
 
@@ -411,11 +412,11 @@ namespace XTMF2.UnitTests
                     };
                     runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
                     {
-                        error = e + "\r\n" + stack;
+                        error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
                     };
                     var runDirectory = Path.Combine(pSession.RunsDirectory, "CheckRunModelSystemRunCompleteData");
-                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, ref error), error);
+                    Assert.IsTrue(runBus.RunModelSystem(msSession, runDirectory, "Start", out var id, out error), error?.Message);
                     // give the models system some time to complete
                     if (!sim.Wait(2000))
                     {

--- a/tests/XTMF2.UnitTests/TestUsers.cs
+++ b/tests/XTMF2.UnitTests/TestUsers.cs
@@ -33,13 +33,13 @@ namespace XTMF2.UnitTests
         {
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
-            string error = null;
+            CommandError error = null;
             const string userName = "NewUser";
             // ensure the user doesn't exist before we start
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error));
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error));
             Assert.IsNull(error);
-            Assert.IsFalse(userController.CreateNew(userName, false, out var secondUser, ref error));
+            Assert.IsFalse(userController.CreateNew(userName, false, out var secondUser, out error));
             Assert.IsNotNull(error);
             error = null;
             Assert.IsTrue(userController.Delete(user));
@@ -51,11 +51,11 @@ namespace XTMF2.UnitTests
             //ensure that a user can survive between different XTMF sessions
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
-            string error = null;
+            CommandError error = null;
             const string userName = "NewUser";
             // ensure the user doesn't exist before we start
             userController.Delete(userName);
-            Assert.IsTrue(userController.CreateNew(userName, false, out var user, ref error));
+            Assert.IsTrue(userController.CreateNew(userName, false, out var user, out error));
             // unload XTMF to simulate it shutting down
             runtime.Shutdown();
             // rebuild XTMF
@@ -72,7 +72,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName1 = "FirstUser";
             const string userName2 = "SecondtUser";
             const string projectName1 = "TestShareBetweenUsers1";
@@ -80,24 +80,24 @@ namespace XTMF2.UnitTests
             // ensure the user doesn't exist before we start and then create our users
             userController.Delete(userName1);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
             // now we need to create a project for both users
 
-            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, ref error), error);
+            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, out error), error?.Message);
 
             // make sure we only have 1 project
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);
 
             // Share project1 with user1
-            Assert.IsTrue(session1.ShareWith(user1, user2, ref error), error);
+            Assert.IsTrue(session1.ShareWith(user1, user2, out error), error?.Message);
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(2, user2.AvailableProjects.Count);
 
-            Assert.IsFalse(session1.ShareWith(user1, user2, ref error), error);
-            Assert.IsFalse(session1.ShareWith(user2, user2, ref error), error);
+            Assert.IsFalse(session1.ShareWith(user1, user2, out error), error?.Message);
+            Assert.IsFalse(session1.ShareWith(user2, user2, out error), error?.Message);
 
             // Delete user1 and make sure that user2 loses reference to project1
             Assert.IsTrue(userController.Delete(user1));
@@ -113,28 +113,28 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName1 = "FirstUser";
             const string userName2 = "SecondtUser";
             const string projectName1 = "TestShareBetweenUsers1";
             // ensure the user doesn't exist before we start and then create our users
             userController.Delete(userName1);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
             // now we need to create a project for both users
 
-            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, ref error), error);
+            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, out error), error?.Message);
             
             // make sure we only have 1 project
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(0, user2.AvailableProjects.Count);
 
-            Assert.IsTrue(session1.ShareWith(user1, user2, ref error));
+            Assert.IsTrue(session1.ShareWith(user1, user2, out error));
             Assert.AreEqual(1, user2.AvailableProjects.Count);
 
             // Ensure that the command fails to be added the second time
-            Assert.IsFalse(session1.ShareWith(user1, user2, ref error));
+            Assert.IsFalse(session1.ShareWith(user1, user2, out error));
             Assert.AreEqual(1, user2.AvailableProjects.Count);
 
             // Delete user1 and make sure that user2 loses reference to project1
@@ -151,7 +151,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName1 = "FirstUser";
             const string userName2 = "SecondtUser";
             const string projectName1 = "TestShareBetweenUsers1";
@@ -159,28 +159,28 @@ namespace XTMF2.UnitTests
             // ensure the user doesn't exist before we start and then create our users
             userController.Delete(userName1);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
             // now we need to create a project for both users
 
-            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, ref error), error);
+            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, out error), error?.Message);
 
             // make sure we only have 1 project
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);
 
             // Share project1 with user1
-            Assert.IsTrue(session1.ShareWith(user1, user2, ref error), error);
+            Assert.IsTrue(session1.ShareWith(user1, user2, out error), error?.Message);
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(2, user2.AvailableProjects.Count);
 
-            Assert.IsFalse(session1.ShareWith(user1, user2, ref error), error);
-            Assert.IsFalse(session1.ShareWith(user2, user2, ref error), error);
+            Assert.IsFalse(session1.ShareWith(user1, user2, out error), error?.Message);
+            Assert.IsFalse(session1.ShareWith(user2, user2, out error), error?.Message);
 
-            Assert.IsFalse(session1.RestrictAccess(user1, user1, ref error));
-            Assert.IsFalse(session1.RestrictAccess(user2, user1, ref error));
-            Assert.IsTrue(session1.RestrictAccess(user1, user2, ref error), error);
+            Assert.IsFalse(session1.RestrictAccess(user1, user1, out error));
+            Assert.IsFalse(session1.RestrictAccess(user2, user1, out error));
+            Assert.IsTrue(session1.RestrictAccess(user1, user2, out error), error?.Message);
 
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);
@@ -199,7 +199,7 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName1 = "FirstUser";
             const string userName2 = "SecondtUser";
             const string projectName1 = "TestShareBetweenUsers1";
@@ -207,30 +207,30 @@ namespace XTMF2.UnitTests
             // ensure the user doesn't exist before we start and then create our users
             userController.Delete(userName1);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
             // now we need to create a project for both users
 
-            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, ref error), error);
-            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, ref error), error);
+            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, out error), error?.Message);
+            Assert.IsTrue(projectController.CreateNewProject(user2, projectName2, out var session2, out error), error?.Message);
 
             // make sure we only have 1 project
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);
 
             // Share project1 with user1
-            Assert.IsTrue(session1.ShareWith(user1, user2, ref error), error);
+            Assert.IsTrue(session1.ShareWith(user1, user2, out error), error?.Message);
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(2, user2.AvailableProjects.Count);
 
-            Assert.IsFalse(session1.ShareWith(user1, user2, ref error), error);
-            Assert.IsFalse(session1.ShareWith(user2, user2, ref error), error);
+            Assert.IsFalse(session1.ShareWith(user1, user2, out error), error?.Message);
+            Assert.IsFalse(session1.ShareWith(user2, user2, out error), error?.Message);
 
-            Assert.IsFalse(session1.RestrictAccess(user1, user1, ref error));
-            Assert.IsFalse(session1.RestrictAccess(user2, user1, ref error));
-            Assert.IsTrue(session1.RestrictAccess(user1, user2, ref error), error);
+            Assert.IsFalse(session1.RestrictAccess(user1, user1, out error));
+            Assert.IsFalse(session1.RestrictAccess(user2, user1, out error));
+            Assert.IsTrue(session1.RestrictAccess(user1, user2, out error), error?.Message);
             // Ensure that we can't do it again
-            Assert.IsFalse(session1.RestrictAccess(user1, user2, ref error), error);
+            Assert.IsFalse(session1.RestrictAccess(user1, user2, out error), error?.Message);
 
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);
@@ -249,24 +249,24 @@ namespace XTMF2.UnitTests
             var runtime = XTMFRuntime.CreateRuntime();
             var userController = runtime.UserController;
             var projectController = runtime.ProjectController;
-            string error = null;
+            CommandError error = null;
             const string userName1 = "FirstUser";
             const string userName2 = "SecondtUser";
             const string projectName1 = "TestShareBetweenUsers1";
             // ensure the user doesn't exist before we start and then create our users
             userController.Delete(userName1);
             userController.Delete(userName2);
-            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, ref error), error);
-            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, ref error), error);
+            Assert.IsTrue(userController.CreateNew(userName1, false, out var user1, out error), error?.Message);
+            Assert.IsTrue(userController.CreateNew(userName2, false, out var user2, out error), error?.Message);
             // now we need to create a project for both users
 
-            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, ref error), error);
+            Assert.IsTrue(projectController.CreateNewProject(user1, projectName1, out var session1, out error), error?.Message);
 
             Assert.AreEqual(1, user1.AvailableProjects.Count);
             Assert.AreEqual(0, user2.AvailableProjects.Count);
 
-            Assert.IsTrue(session1.SwitchOwner(user1, user2, ref error), error);
-            Assert.IsFalse(session1.SwitchOwner(user1, user2, ref error));
+            Assert.IsTrue(session1.SwitchOwner(user1, user2, out error), error?.Message);
+            Assert.IsFalse(session1.SwitchOwner(user1, user2, out error));
 
             Assert.AreEqual(0, user1.AvailableProjects.Count);
             Assert.AreEqual(1, user2.AvailableProjects.Count);


### PR DESCRIPTION
This PR replaces the pattern of using "ref string error" for command that the GUI could invoke into "out CommandError error".  This will allow the GUI to detect if the error was caused by an unauthorized user.