### PR TITLE
Invalid Run Directory for Linux

### DIFF
--- a/src/XTMF2/Project.cs
+++ b/src/XTMF2/Project.cs
@@ -516,6 +516,11 @@ namespace XTMF2
                     dir.Create();
                 }
             }
+            catch (ArgumentException e)
+            {
+                error = new CommandError($"Unable to use '{runDirectory}' for the custom runs directory. {e.Message}");
+                return false;
+            }
             catch (IOException e)
             {
                 error = new CommandError($"Unable to use '{runDirectory}' for the custom runs directory. {e.Message}");

--- a/tests/XTMF2.UnitTests/TestProjects.cs
+++ b/tests/XTMF2.UnitTests/TestProjects.cs
@@ -463,8 +463,8 @@ namespace XTMF2.UnitTests
             {
                 CommandError error = null;
                 var initialDirectory = project.RunsDirectory;
-                const string anInvalidPath = ":?!@#://#%$^&|";
-                Assert.IsFalse(project.SetCustomRunDirectory(user, anInvalidPath, out error), "An invalid path was able to be set.");
+                var invalidCharacters = Path.GetInvalidFileNameChars();
+                Assert.IsFalse(project.SetCustomRunDirectory(user, new string(invalidCharacters), out error), "An invalid path was able to be set.");
                 Assert.AreEqual(initialDirectory, project.RunsDirectory);
             });
         }


### PR DESCRIPTION
Updated the unit test to not allow any characters that are illegal in a filename based on the operating system.  Currently the unit test fails to "fail" on Linux because the given directory name is actually valid.