### PR TITLE
Implemented deleting multiple nodes

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -1198,17 +1198,27 @@ public sealed class ModelSystemCanvas : Control
     {
         base.OnKeyDown(e);
         if (_vm is null) return;
-        if (e.Key is Key.Delete or Key.Back)
+        else if (e.Key is Key.Delete or Key.Back)
         {
-            _vm.DeleteSelectedCommand.Execute(null);
+            if (_multiSelection.Count > 1)
+            {
+                // Snapshot the set before clearing so deletions don't mutate it mid-loop.
+                var toDelete = _multiSelection.ToList();
+                ClearMultiSelection();
+                _ = _vm.DeleteMultipleAsync(toDelete);
+            }
+            else
+            {
+                _vm.DeleteSelectedCommand.Execute(null);
+            }
             e.Handled = true;
         }
-        if (e.Key == Key.D0 && (e.KeyModifiers & KeyModifiers.Control) != 0)
+        else if (e.Key == Key.D0 && (e.KeyModifiers & KeyModifiers.Control) != 0)
         {
             ApplyScale(1.0);
             e.Handled = true;
         }
-        if(e.Key == Key.Escape)
+        else if (e.Key == Key.Escape)
         {
             ClearMultiSelection();
             e.Handled = true;

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -1272,6 +1272,36 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
                 lvm.IsSelected = selected;
     }
 
+    /// <summary>
+    /// Deletes all elements in <paramref name="elements"/> in one batch.
+    /// Called by the canvas when the Delete key is pressed with a multi-selection active.
+    /// Nodes, Starts, and CommentBlocks are supported; any other element types are silently skipped.
+    /// The first error encountered (if any) is shown to the user after all removals are attempted.
+    /// </summary>
+    public async Task DeleteMultipleAsync(IReadOnlyList<ICanvasElement> elements)
+    {
+        // Clear the primary selection so the property panel de-focuses immediately.
+        SelectElement(null);
+
+        CommandError? firstError = null;
+        foreach (var el in elements)
+        {
+            CommandError? err = null;
+            bool ok = el switch
+            {
+                NodeViewModel         nvm => Session.RemoveNode(User, nvm.UnderlyingNode, out err),
+                StartViewModel        svm => Session.RemoveStart(User, svm.UnderlyingStart, out err),
+                CommentBlockViewModel cvm => Session.RemoveCommentBlock(User, _currentBoundary, cvm.UnderlyingBlock, out err),
+                _                        => true,
+            };
+            if (!ok && err is not null)
+                firstError ??= err;
+        }
+
+        if (firstError is not null)
+            await ShowError("Delete Failed", firstError);
+    }
+
     /// <summary>Delete whichever element or link is currently selected.</summary>
     [RelayCommand]
     private async Task DeleteSelected()


### PR DESCRIPTION
This update allows you to delete all of the nodes/modules that are selected.  The currently behavior would only delete the Canvas' `SelectedItem`.