### PR TITLE
Scale Editing Text

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -441,6 +441,7 @@ public sealed class ModelSystemCanvas : Control
         // Position the inline editor at the stored row location (scaled to screen coords).
         if (_editingParamNode is not null && _editingParamEditorW > 0)
         {
+            _inlineEditor.FontSize = HookFontSize * _scale;
             _inlineEditor.Arrange(new Rect(
                 _editingParamEditorX * _scale,
                 _editingParamEditorY * _scale,


### PR DESCRIPTION
In the current implementation the size of the text for the parameter currently being editing is always at 100%.  This patch changes that by scaling the size of the text to match the rest of the cavas.
