### PR TITLE
Extract FunctionTemplate

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -2846,6 +2846,22 @@ public sealed class ModelSystemCanvas : Control
             _ = PasteElementsAsync(vx, vy);
             e.Handled = true;
         }
+        else if (e.Key == Key.M
+                 && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Shift))
+                    == (KeyModifiers.Control | KeyModifiers.Shift))
+        {
+            // Ctrl+Shift+M: extract selected nodes to a Function Template.
+            IReadOnlyList<ICanvasElement> toExtract = _multiSelection.Count > 1
+                ? _multiSelection.ToList()
+                : _vm?.SelectedElement is { } sel
+                    ? new[] { sel }
+                    : System.Array.Empty<ICanvasElement>();
+            if (toExtract.Count > 0 && _vm is not null)
+            {
+                _ = _vm.ExtractSelectionToFunctionTemplateAsync(toExtract);
+                e.Handled = true;
+            }
+        }
     }
 
     // ── Copy / Paste helpers ──────────────────────────────────────────────
@@ -4300,6 +4316,35 @@ public sealed class ModelSystemCanvas : Control
             menu.Items.Add(new Separator());
             menu.Items.Add(ghostItem);
             menu.Items.Add(moveNodeItem);
+        }
+
+        // ── Extract to Function Template ───────────────────────────────────────
+        // Available for regular nodes and function instances when NOT already inside
+        // a function template's InternalModules view.
+        if ((element is NodeViewModel extractSourceNode && !extractSourceNode.IsParameterNode
+             || element is FunctionInstanceViewModel)
+            && !vm.IsInsideFunctionTemplate)
+        {
+            // If the right-clicked element is part of a multi-selection, operate on all
+            // selected extractable elements; otherwise operate on just this one.
+            IReadOnlyList<ICanvasElement> selElements =
+                _multiSelection.Count > 1 && _multiSelection.Contains(element)
+                ? _multiSelection.ToList()
+                : new[] { element! };
+
+            int extractCount = selElements.Count(el =>
+                el is NodeViewModel envm && !envm.IsParameterNode
+                || el is FunctionInstanceViewModel);
+
+            string extractHeader = extractCount > 1
+                ? $"Extract {extractCount} Elements to Function Template…\tCtrl+Shift+M"
+                : "Extract to Function Template…\tCtrl+Shift+M";
+
+            var capturedExtractElements = selElements;
+            var extractItem = new MenuItem { Header = extractHeader };
+            extractItem.Click += (_, _) => _ = vm.ExtractSelectionToFunctionTemplateAsync(capturedExtractElements);
+            menu.Items.Add(new Separator());
+            menu.Items.Add(extractItem);
         }
 
         // ── Move to Boundary (ghost nodes) ────────────────────────────────────

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -163,6 +163,13 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
     /// <summary>Observable wrappers around <see cref="Boundary.Links"/>.</summary>
     public ObservableCollection<LinkViewModel> Links { get; } = new();
 
+    /// <summary>
+    /// Tracks the <see cref="INotifyPropertyChanged.PropertyChanged"/> handlers registered
+    /// on <see cref="SingleLink"/> objects so they can be properly unsubscribed when the
+    /// link is removed from the boundary or the boundary switches.
+    /// </summary>
+    private readonly Dictionary<SingleLink, System.ComponentModel.PropertyChangedEventHandler> _singleLinkDestHandlers = new();
+
     /// <summary>Observable wrappers around <see cref="Boundary.CommentBlocks"/>.</summary>
     public ObservableCollection<CommentBlockViewModel> CommentBlocks { get; } = new();
 
@@ -649,6 +656,10 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
 
         UnsubscribeFromBoundary(_currentBoundary);
         foreach (var lvm in Links) lvm.Detach();
+        // Unsubscribe all SingleLink destination-change handlers tracked for the old boundary.
+        foreach (var (sl, h) in _singleLinkDestHandlers)
+            sl.PropertyChanged -= h;
+        _singleLinkDestHandlers.Clear();
         Nodes.Clear();
         Starts.Clear();
         Links.Clear();
@@ -769,6 +780,14 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
                     vm.Detach();
                     Links.Remove(vm);
                 }
+
+                // Unsubscribe the destination-change handler registered in TryAddLinkViewModel.
+                if (link is SingleLink removedSl
+                    && _singleLinkDestHandlers.TryGetValue(removedSl, out var h))
+                {
+                    removedSl.PropertyChanged -= h;
+                    _singleLinkDestHandlers.Remove(removedSl);
+                }
             }
     }
 
@@ -888,7 +907,35 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         else if (link is SingleLink sl)
         {
             Links.Add(new LinkViewModel(link, originElement, ResolveElement(sl.Destination)));
+
+            // When SetDestination() is called on the underlying model link (e.g. by
+            // ExtractToFunctionTemplate), rebuild the LinkViewModel so it points at the
+            // new destination canvas element rather than continuing to float.
+            System.ComponentModel.PropertyChangedEventHandler destHandler = (_, args) =>
+            {
+                if (args.PropertyName is nameof(SingleLink.Destination))
+                    ReplaceSingleLinkViewModel(sl, originElement);
+            };
+            _singleLinkDestHandlers[sl] = destHandler;
+            sl.PropertyChanged += destHandler;
         }
+    }
+
+    /// <summary>
+    /// Replaces the <see cref="LinkViewModel"/> for a <see cref="SingleLink"/> whose
+    /// <see cref="SingleLink.Destination"/> has just changed (e.g. via
+    /// <c>ExtractToFunctionTemplate</c>). The stale VM is detached and removed; a fresh
+    /// one is created and added so the canvas arrow binds to the correct target element.
+    /// </summary>
+    private void ReplaceSingleLinkViewModel(SingleLink sl, ICanvasElement originElement)
+    {
+        var old = Links.FirstOrDefault(lvm => lvm.UnderlyingLink == sl);
+        if (old is not null)
+        {
+            old.Detach();
+            Links.Remove(old);
+        }
+        Links.Add(new LinkViewModel(sl, originElement, ResolveElement(sl.Destination)));
     }
 
     private void OnMultiLinkDestinationsChanged(
@@ -3023,6 +3070,89 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         }
 
         Session.SetFunctionTemplateLocation(User, ft!, ftLocation, out _);
+    }
+
+    /// <summary>
+    /// Prompts for template and instance names then extracts the specified canvas elements
+    /// into an in-place <see cref="FunctionTemplate"/> + <see cref="FunctionInstance"/>.
+    /// Shows a toast on failure.
+    /// </summary>
+    public async Task ExtractSelectionToFunctionTemplateAsync(IReadOnlyList<ICanvasElement> elements)
+    {
+        if (ParentWindow is null) return;
+
+        // Collect the underlying Node objects (regular nodes + function instances).
+        var nodes = elements
+            .Select(el => el switch
+            {
+                NodeViewModel             nvm  => (Node?)nvm.UnderlyingNode,
+                FunctionInstanceViewModel fivm => fivm.UnderlyingInstance,
+                _                             => null,
+            })
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .ToList();
+
+        if (nodes.Count == 0)
+        {
+            ShowToast("No extractable nodes in the selection.", isError: true, durationMs: 4000);
+            return;
+        }
+
+        // Default template name: first name not already taken.
+        int idx = FunctionTemplates.Count + 1;
+        string defaultFtName;
+        do { defaultFtName = $"FunctionTemplate{idx++}"; }
+        while (FunctionTemplates.Any(ft => string.Equals(ft.Name, defaultFtName, StringComparison.OrdinalIgnoreCase)));
+
+        var ftNameDialog = new InputDialog(
+            title: "Extract to Function Template",
+            prompt: "Enter function template name:",
+            defaultText: defaultFtName);
+        await ftNameDialog.ShowDialog(ParentWindow);
+        if (ftNameDialog.WasCancelled) return;
+        var ftName = ftNameDialog.InputText?.Trim() ?? string.Empty;
+
+        var fiNameDialog = new InputDialog(
+            title: "Extract to Function Template",
+            prompt: "Enter function instance name:",
+            defaultText: ftName);
+        await fiNameDialog.ShowDialog(ParentWindow);
+        if (fiNameDialog.WasCancelled) return;
+        var fiName = fiNameDialog.InputText?.Trim() ?? string.Empty;
+
+        // Compute bounding box of selected nodes to derive placement.
+        float minX = nodes.Min(n => n.Location.X);
+        float minY = nodes.Min(n => n.Location.Y);
+        float maxX = nodes.Max(n => n.Location.X + n.Location.Width);
+        float maxY = nodes.Max(n => n.Location.Y + n.Location.Height);
+
+        // FunctionInstance inherits the centroid of the bounding box.
+        const float FiWidth  = 160f;
+        const float FiHeight =  60f;
+        var fiLocation = new Rectangle(
+            (minX + maxX - FiWidth)  / 2f,
+            (minY + maxY - FiHeight) / 2f,
+            FiWidth, FiHeight);
+
+        // FunctionTemplate placed below the selection.
+        const float FtGap    =  40f;
+        const float FtWidth  = 320f;
+        const float FtHeight = 220f;
+        var ftLocation = new Rectangle(
+            (minX + maxX - FtWidth) / 2f,
+            maxY + FtGap,
+            FtWidth, FtHeight);
+
+        if (!Session.ExtractToFunctionTemplate(
+                User, _currentBoundary, nodes,
+                ftName, fiName,
+                ftLocation, fiLocation,
+                out _, out _, out var error))
+        {
+            ShowToast(error?.Message ?? "Could not extract to function template.",
+                      isError: true, durationMs: 6000);
+        }
     }
 
     /// <summary>Pick a template (when more than one exists) then place a new function instance at the specified canvas position with an auto-generated name.</summary>

--- a/src/XTMF2/Editing/ModelSystemSession.cs
+++ b/src/XTMF2/Editing/ModelSystemSession.cs
@@ -3497,6 +3497,445 @@ namespace XTMF2.Editing
             }
         }
 
+        // ── ExtractToFunctionTemplate ─────────────────────────────────────
+
+        /// <summary>
+        /// Extracts a set of nodes from <paramref name="boundary"/> into a newly created
+        /// <see cref="FunctionTemplate"/> and places a <see cref="FunctionInstance"/> of that
+        /// template in the same boundary in-place.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// All nodes in <paramref name="selectedNodes"/> must reside in
+        /// <paramref name="boundary"/>.  Exactly one link must come <em>from outside</em> the
+        /// selection into the selection; that link's destination node becomes the template's
+        /// <see cref="FunctionTemplate.EntryNode"/>.
+        /// </para>
+        /// <para>
+        /// Every SingleLink whose origin is inside the selection and whose destination is
+        /// <em>outside</em> the selection (and not a Rectangle.Hidden inline-parameter node)
+        /// is converted into a <see cref="FunctionParameter"/> on the new template.
+        /// The corresponding <see cref="FunctionInstance"/> hook is then wired to the original
+        /// external destination.
+        /// </para>
+        /// <para>The entire operation is registered as a single undoable command.</para>
+        /// </remarks>
+        /// <param name="user">The user issuing the command.</param>
+        /// <param name="boundary">The boundary that contains the selected nodes.</param>
+        /// <param name="selectedNodes">The nodes to extract. Must all reside in <paramref name="boundary"/>.</param>
+        /// <param name="functionTemplateName">Name for the new <see cref="FunctionTemplate"/>. Must be unique in the model system.</param>
+        /// <param name="functionInstanceName">Name for the new <see cref="FunctionInstance"/>.</param>
+        /// <param name="functionTemplateLocation">Canvas location for the function template box.</param>
+        /// <param name="functionInstanceLocation">Canvas location for the function instance.</param>
+        /// <param name="functionTemplate">The newly created template on success.</param>
+        /// <param name="functionInstance">The newly created instance on success.</param>
+        /// <param name="error">Error description when the method returns <c>false</c>.</param>
+        /// <returns><c>true</c> on success; <c>false</c> with a populated <paramref name="error"/> on failure.</returns>
+        public bool ExtractToFunctionTemplate(
+            User user,
+            Boundary boundary,
+            IReadOnlyList<Node> selectedNodes,
+            string functionTemplateName,
+            string functionInstanceName,
+            Rectangle functionTemplateLocation,
+            Rectangle functionInstanceLocation,
+            out FunctionTemplate? functionTemplate,
+            out FunctionInstance? functionInstance,
+            [NotNullWhen(false)] out CommandError? error)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(boundary);
+            ArgumentNullException.ThrowIfNull(selectedNodes);
+            functionTemplate = null;
+            functionInstance = null;
+
+            if (selectedNodes.Count == 0)
+            {
+                error = new CommandError("At least one node must be selected for extraction.");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(functionTemplateName))
+            {
+                error = new CommandError("A function template name must not be empty.");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(functionInstanceName))
+            {
+                error = new CommandError("A function instance name must not be empty.");
+                return false;
+            }
+
+            lock (_sessionLock)
+            {
+                if (!_session.HasAccess(user))
+                {
+                    error = new CommandError("The user does not have access to this project.", true);
+                    return false;
+                }
+
+                var selectedSet = new HashSet<Node>();
+                foreach (var n in selectedNodes)
+                    selectedSet.Add(n);
+
+                // ── Validate all selected nodes live in the specified boundary ──
+                foreach (var n in selectedNodes)
+                {
+                    if (!ReferenceEquals(n.ContainedWithin, boundary))
+                    {
+                        error = new CommandError(
+                            $"Node '{n.Name}' does not reside in boundary '{boundary.Name}'.");
+                        return false;
+                    }
+                    if (n is FunctionParameter)
+                    {
+                        error = new CommandError(
+                            $"Node '{n.Name}' is a FunctionParameter and cannot be extracted.");
+                        return false;
+                    }
+                }
+
+                // ── Classify links ─────────────────────────────────────────────
+                // External incoming: origin outside selection, destination (single) inside selection.
+                var externalIncomingLinks = boundary.Links
+                    .Where(l => l is SingleLink sl
+                                && !selectedSet.Contains(l.Origin)
+                                && selectedSet.Contains(sl.Destination))
+                    .Cast<SingleLink>()
+                    .ToList();
+
+                if (externalIncomingLinks.Count != 1)
+                {
+                    error = new CommandError(
+                        $"Extraction requires exactly one external incoming link, " +
+                        $"but {externalIncomingLinks.Count} were found.");
+                    return false;
+                }
+
+                var externalIncoming = externalIncomingLinks[0];
+                var entryNode        = externalIncoming.Destination;
+
+                // Reject mixed MultiLinks that cross the selection boundary (some dests in, some out).
+                var ambiguousMulti = boundary.Links
+                    .Where(l => l is MultiLink ml
+                                && selectedSet.Contains(l.Origin)
+                                && ml.Destinations.Any(d => selectedSet.Contains(d))
+                                && ml.Destinations.Any(d => !selectedSet.Contains(d)))
+                    .ToList();
+                if (ambiguousMulti.Count > 0)
+                {
+                    error = new CommandError(
+                        "Extraction is not supported when a MultiLink has destinations both " +
+                        "inside and outside the selection.");
+                    return false;
+                }
+
+                // Reject fully-external MultiLinks (all dests outside): they are ambiguous as FPs.
+                var externalMultiLinks = boundary.Links
+                    .Where(l => l is MultiLink ml2
+                                && selectedSet.Contains(l.Origin)
+                                && ml2.Destinations.All(d => !selectedSet.Contains(d)))
+                    .ToList();
+                if (externalMultiLinks.Count > 0)
+                {
+                    error = new CommandError(
+                        "Extraction is not supported when a MultiLink exits the selection entirely. " +
+                        "Replace it with individual SingleLinks before extracting.");
+                    return false;
+                }
+
+                // External outgoing SingleLinks: origin inside, destination outside, not a hidden child.
+                var externalOutgoing = boundary.Links
+                    .Where(l => l is SingleLink sl2
+                                && selectedSet.Contains(l.Origin)
+                                && !selectedSet.Contains(sl2.Destination)
+                                && !sl2.Destination.Location.Equals(Rectangle.Hidden))
+                    .Cast<SingleLink>()
+                    .ToList();
+
+                // ── Validate FunctionTemplate name uniqueness ──────────────────
+                if (ModelSystem.GlobalBoundary.ContainsFunctionTemplateName(functionTemplateName))
+                {
+                    error = new CommandError(
+                        $"A FunctionTemplate named '{functionTemplateName}' already exists in the model system.");
+                    return false;
+                }
+
+                // ══════════════════════════════════════════════════════════════
+                // Perform the extraction (no more early returns with error after
+                // this point -- all validation is done above).
+                // ══════════════════════════════════════════════════════════════
+
+                // Step 1 – Create FunctionTemplate.
+                if (!boundary.AddFunctionTemplate(functionTemplateName, out var ft, out error))
+                    return false;
+                ft!.SetLocation(functionTemplateLocation);
+                var internalBoundary = ft.InternalModules;
+
+                // Step 2 – Remove external outgoing links from boundary so they don't follow
+                //          their origin nodes into InternalModules during the move.
+                foreach (var link in externalOutgoing)
+                    boundary.RemoveLink(link, out _);
+
+                // Step 3 – Move each selected node (and its hidden inline children) to
+                //          InternalModules.  Their remaining outgoing links (internal ones
+                //          plus links to hidden children) also move.
+                var moveInfo = new List<(Node Node, List<Node> HiddenChildren, List<Link> MovedLinks)>();
+                foreach (var node in selectedNodes)
+                {
+                    // Collect outgoing links still present in boundary (external ones were removed above).
+                    var nodeOutgoing = boundary.Links.Where(l => l.Origin == node).ToList();
+
+                    // Collect hidden inline-parameter children.
+                    var hiddenChildrenSet = new HashSet<Node>();
+                    foreach (var lk in nodeOutgoing)
+                    {
+                        IEnumerable<Node> dests = lk is SingleLink slH && slH.Destination is not null
+                            ? new[] { slH.Destination }
+                            : lk is MultiLink mlH
+                                ? (IEnumerable<Node>)mlH.Destinations
+                                : Array.Empty<Node>();
+                        foreach (var dn in dests)
+                        {
+                            if (dn.Location.Equals(Rectangle.Hidden)
+                                && ReferenceEquals(dn.ContainedWithin, boundary))
+                                hiddenChildrenSet.Add(dn);
+                        }
+                    }
+                    var hiddenChildren = hiddenChildrenSet.ToList();
+
+                    // Remove links from boundary.
+                    foreach (var lk in nodeOutgoing)
+                        boundary.RemoveLink(lk, out _);
+
+                    // Move node and hidden children.
+                    boundary.RemoveNode(node, out _);
+                    node.UpdateContainedWithin(internalBoundary);
+                    internalBoundary.AddNode(node, out _);
+
+                    foreach (var hc in hiddenChildren)
+                    {
+                        boundary.RemoveNode(hc, out _);
+                        hc.UpdateContainedWithin(internalBoundary);
+                        internalBoundary.AddNode(hc, out _);
+                    }
+
+                    // Re-add outgoing links to InternalModules.
+                    foreach (var lk in nodeOutgoing)
+                        internalBoundary.AddLink(lk, out _);
+
+                    moveInfo.Add((node, hiddenChildren, nodeOutgoing));
+                }
+
+                // Compute the bounding box of the selected nodes so we can place
+                // FunctionParameters visibly above them, centred horizontally.
+                const float FpWidth  = 120f;
+                const float FpHeight =  50f;
+                const float FpGap    =  20f;
+                float bboxMinX = float.MaxValue, bboxMaxX = float.MinValue, bboxMinY = float.MaxValue;
+                foreach (var node in selectedNodes)
+                {
+                    var loc = node.Location;
+                    if (loc.Equals(Rectangle.Hidden)) continue;
+                    if (loc.X         < bboxMinX) bboxMinX = loc.X;
+                    if (loc.X + loc.Width  > bboxMaxX) bboxMaxX = loc.X + loc.Width;
+                    if (loc.Y         < bboxMinY) bboxMinY = loc.Y;
+                }
+                // Fallback when every selected node is hidden / has no location.
+                if (bboxMinX == float.MaxValue) { bboxMinX = 0f; bboxMaxX = 120f; bboxMinY = 100f; }
+                int fpCount = externalOutgoing.Count;
+                float totalFpWidth = fpCount * FpWidth + MathF.Max(0, fpCount - 1) * FpGap;
+                float fpStartX     = (bboxMinX + bboxMaxX) / 2f - totalFpWidth / 2f;
+                float fpY          = MathF.Max(0f, bboxMinY - FpHeight - 40f);
+
+                // Step 4 – Create FunctionParameters and internal FP-destination links.
+                var usedFpNames = new HashSet<string>(StringComparer.Ordinal);
+                var fpData = new List<(FunctionParameter Fp, SingleLink ExternalLink, SingleLink InternalFpLink)>();
+                int fpIndex = 0;
+                foreach (var extLink in externalOutgoing)
+                {
+                    var hookType = extLink.OriginHook.Type;
+                    var fpName   = extLink.OriginHook.Name;
+
+                    // Ensure name uniqueness within the template.
+                    if (usedFpNames.Contains(fpName))
+                    {
+                        int suffix = 1;
+                        while (usedFpNames.Contains($"{fpName}_{suffix}")) suffix++;
+                        fpName = $"{fpName}_{suffix}";
+                    }
+                    usedFpNames.Add(fpName);
+
+                    var fpRect = new Rectangle(fpStartX + fpIndex * (FpWidth + FpGap), fpY, FpWidth, FpHeight);
+                    ft.AddFunctionParameter(fpName, hookType, fpRect, out var fp, out _);
+                    fpIndex++;
+                    var internalFpLink = new SingleLink(extLink.Origin, extLink.OriginHook, fp!, false);
+                    internalBoundary.AddLink(internalFpLink, out _);
+                    fpData.Add((fp!, extLink, internalFpLink));
+                }
+
+                // Step 5 – Create FunctionInstance.
+                boundary.AddFunctionInstance(functionInstanceName, ft, functionInstanceLocation,
+                    out var fi, out _);
+
+                // Step 6 – Set the entry node on the template.
+                ft.SetEntryNode(entryNode);
+
+                // Step 7 – Redirect the external incoming link to the new FunctionInstance.
+                externalIncoming.SetDestination(fi!, out _);
+
+                // Step 8 – Create links from the FunctionInstance's hooks to the external destinations.
+                var fiOutgoingLinks = new List<SingleLink>();
+                foreach (var (fp, extLink, _) in fpData)
+                {
+                    var fiHook = fi!.Hooks
+                        .OfType<FunctionParameterHook>()
+                        .FirstOrDefault(h => ReferenceEquals(h.Parameter, fp));
+                    if (fiHook is not null)
+                    {
+                        var fiLink = new SingleLink(fi, fiHook, extLink.Destination, false);
+                        boundary.AddLink(fiLink, out _);
+                        fiOutgoingLinks.Add(fiLink);
+                    }
+                }
+
+                functionTemplate = ft;
+                functionInstance = fi!;
+                error = null;
+
+                // ── Register a single undo/redo command ────────────────────────
+                var capturedFt              = ft;
+                var capturedFi              = fi!;
+                var capturedEntryNode       = entryNode;
+                var capturedExternalIn      = externalIncoming;
+                var capturedFpData          = fpData;
+                var capturedMoveInfo        = moveInfo;
+                var capturedExternalOut     = externalOutgoing;
+                var capturedFiOutgoing      = fiOutgoingLinks;
+
+                Buffer.AddUndo(new Command(
+                    // ── Undo ──
+                    () =>
+                    {
+                        // 1. Remove fi→external links.
+                        foreach (var lk in capturedFiOutgoing)
+                            boundary.RemoveLink(lk, out _);
+
+                        // 2. Move nodes back from InternalModules to boundary FIRST so that
+                        //    when SetDestination fires PropertyChanged below, the destination
+                        //    node VM already exists in the boundary and the link can bind correctly.
+                        //    Pass 1: move all nodes (and their hidden children) back first so that
+                        //    every NodeViewModel exists before any link tries to resolve its destination.
+                        foreach (var (node, hiddenChildren, movedLinks) in capturedMoveInfo)
+                        {
+                            // Remove outgoing links from InternalModules.
+                            foreach (var lk in movedLinks)
+                                internalBoundary.RemoveLink(lk, out _);
+
+                            // Move node and hidden children back.
+                            internalBoundary.RemoveNode(node, out _);
+                            node.UpdateContainedWithin(boundary);
+                            boundary.AddNode(node, out _);
+
+                            foreach (var hc in hiddenChildren)
+                            {
+                                internalBoundary.RemoveNode(hc, out _);
+                                hc.UpdateContainedWithin(boundary);
+                                boundary.AddNode(hc, out _);
+                            }
+                        }
+
+                        //    Pass 2: now that all destination NodeViewModels exist in the boundary,
+                        //    re-add the links so TryAddLinkViewModel can resolve both endpoints.
+                        foreach (var (_, _, movedLinks) in capturedMoveInfo)
+                            foreach (var lk in movedLinks)
+                                boundary.AddLink(lk, out _);
+
+                        // 3. Re-add the original external outgoing links to boundary.
+                        foreach (var lk in capturedExternalOut)
+                            boundary.AddLink(lk, out _);
+
+                        // 4. Restore external incoming link destination (fires PropertyChanged;
+                        //    capturedEntryNode is now in the boundary so the VM resolves correctly).
+                        capturedExternalIn.SetDestination(capturedEntryNode, out _);
+
+                        // 5. Clear the entry node.
+                        capturedFt.SetEntryNode(null);
+
+                        // 6. Remove FunctionInstance.
+                        boundary.RemoveFunctionInstance(capturedFi, out _);
+
+                        // 7. Remove internal FP-destination links and FunctionParameters.
+                        foreach (var (fp, _, internalFpLink) in capturedFpData)
+                        {
+                            internalBoundary.RemoveLink(internalFpLink, out _);
+                            capturedFt.RemoveFunctionParameter(fp, out _);
+                        }
+
+                        // 8. Remove the FunctionTemplate.
+                        boundary.RemoveFunctionTemplate(capturedFt, out _);
+
+                        return (true, null);
+                    },
+                    // ── Redo ──
+                    () =>
+                    {
+                        // Re-add FunctionTemplate.
+                        boundary.AddFunctionTemplate(capturedFt, out _);
+                        capturedFt.SetLocation(functionTemplateLocation);
+
+                        // Remove external outgoing links.
+                        foreach (var lk in capturedExternalOut)
+                            boundary.RemoveLink(lk, out _);
+
+                        // Move nodes to InternalModules.
+                        foreach (var (node, hiddenChildren, movedLinks) in capturedMoveInfo)
+                        {
+                            foreach (var lk in movedLinks)
+                                boundary.RemoveLink(lk, out _);
+
+                            boundary.RemoveNode(node, out _);
+                            node.UpdateContainedWithin(internalBoundary);
+                            internalBoundary.AddNode(node, out _);
+
+                            foreach (var hc in hiddenChildren)
+                            {
+                                boundary.RemoveNode(hc, out _);
+                                hc.UpdateContainedWithin(internalBoundary);
+                                internalBoundary.AddNode(hc, out _);
+                            }
+
+                            foreach (var lk in movedLinks)
+                                internalBoundary.AddLink(lk, out _);
+                        }
+
+                        // Re-add FPs and internal FP links.
+                        foreach (var (fp, _, internalFpLink) in capturedFpData)
+                        {
+                            capturedFt.RestoreFunctionParameter(fp, capturedFt.FunctionParameters.Count);
+                            internalBoundary.AddLink(internalFpLink, out _);
+                        }
+
+                        // Re-add FunctionInstance.
+                        boundary.AddFunctionInstance(capturedFi, out _);
+
+                        // Set entry node.
+                        capturedFt.SetEntryNode(capturedEntryNode);
+
+                        // Redirect external incoming link.
+                        capturedExternalIn.SetDestination(capturedFi, out _);
+
+                        // Re-add fi→external links.
+                        foreach (var lk in capturedFiOutgoing)
+                            boundary.AddLink(lk, out _);
+
+                        return (true, null);
+                    }
+                ));
+
+                return true;
+            }
+        }
+
         /// <summary>
         /// Export the model system to a file at the given path.
         /// </summary>

--- a/tests/XTMF2.UnitTests/Editing/TestExtractToFunctionTemplate.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestExtractToFunctionTemplate.cs
@@ -50,9 +50,9 @@ public class TestExtractToFunctionTemplate
         Node caller, NodeHook callerHook,
         Node entryNode,
         Node externalDest, NodeHook entryHook,
-        out FunctionTemplate? ft,
-        out FunctionInstance? fi,
-        out CommandError? error)
+        out FunctionTemplate ft,
+        out FunctionInstance fi,
+        out CommandError error)
     {
         var boundary = ms.ModelSystem.GlobalBoundary;
         // Wire caller → entryNode.
@@ -212,7 +212,7 @@ public class TestExtractToFunctionTemplate
                 Assert.AreSame(fi, boundary.FunctionInstances[0]);
 
                 // entryNode must have left the boundary.
-                Assert.IsFalse(boundary.Modules.Contains(entryNode),
+                Assert.DoesNotContain(entryNode, boundary.Modules,
                     "entryNode must no longer be in the parent boundary.");
 
                 // The incoming link (start → fi) must be in place.
@@ -275,11 +275,11 @@ public class TestExtractToFunctionTemplate
 
                 // ── Verify parent boundary ─────────────────────────────────
                 // entryNode gone from parent.
-                Assert.IsFalse(boundary.Modules.Contains(entryNode),
+                Assert.DoesNotContain(entryNode, boundary.Modules,
                     "entryNode must be in InternalModules, not the parent boundary.");
 
                 // externalDest stays in parent.
-                Assert.IsTrue(boundary.Modules.Contains(externalDest!),
+                Assert.Contains(externalDest!, boundary.Modules,
                     "externalDest must remain in the parent boundary.");
 
                 // start → fi link.
@@ -437,7 +437,7 @@ public class TestExtractToFunctionTemplate
                 // State after extraction.
                 Assert.HasCount(1, boundary.FunctionTemplates);
                 Assert.HasCount(1, boundary.FunctionInstances);
-                Assert.IsFalse(boundary.Modules.Contains(entryNode));
+                Assert.DoesNotContain(entryNode, boundary.Modules);
 
                 // Undo.
                 Assert.IsTrue(ms.Undo(user, out error), error?.Message);
@@ -449,7 +449,7 @@ public class TestExtractToFunctionTemplate
                     "Undo must remove the FunctionInstance.");
 
                 // entryNode is back in the boundary.
-                Assert.IsTrue(boundary.Modules.Contains(entryNode),
+                Assert.Contains(entryNode, boundary.Modules,
                     "entryNode must be back in the parent boundary.");
                 Assert.AreSame(boundary, entryNode.ContainedWithin,
                     "entryNode.ContainedWithin must point to the parent boundary again.");
@@ -512,7 +512,7 @@ public class TestExtractToFunctionTemplate
 
                 // entryNode back in InternalModules.
                 var ft = boundary.FunctionTemplates[0];
-                Assert.IsTrue(ft.InternalModules.Modules.Contains(entryNode),
+                Assert.Contains(entryNode, ft.InternalModules.Modules,
                     "entryNode must be back in InternalModules after redo.");
 
                 // start → fi link.

--- a/tests/XTMF2.UnitTests/Editing/TestExtractToFunctionTemplate.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestExtractToFunctionTemplate.cs
@@ -1,0 +1,654 @@
+/*
+    Copyright 2026, Travel Modelling Group, University of Toronto
+
+    This file is part of XTMF2.
+
+    XTMF2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF2.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using XTMF2.Editing;
+using XTMF2.ModelSystemConstruct;
+using XTMF2.RuntimeModules;
+using XTMF2.UnitTests.Modules;
+
+namespace XTMF2.UnitTests.Editing;
+
+/// <summary>
+/// Tests for <see cref="ModelSystemSession.ExtractToFunctionTemplate"/>.
+/// </summary>
+[TestClass]
+public class TestExtractToFunctionTemplate
+{
+    // ── Locations ──────────────────────────────────────────────────────────
+    private static readonly Rectangle CallerLoc   = new(0,   0,  160, 60);
+    private static readonly Rectangle EntryLoc    = new(200, 0,  160, 60);
+    private static readonly Rectangle ExtDestLoc  = new(400, 0,  160, 60);
+    private static readonly Rectangle FtLoc       = new(200, 100, 300, 200);
+    private static readonly Rectangle FiLoc       = new(200, 0,  160, 60);
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a minimal "caller → entryNode → externalDest" graph and extracts
+    /// entryNode into a FunctionTemplate.
+    /// </summary>
+    private static bool RunExtract(
+        User user, ModelSystemSession ms,
+        Node caller, NodeHook callerHook,
+        Node entryNode,
+        Node externalDest, NodeHook entryHook,
+        out FunctionTemplate? ft,
+        out FunctionInstance? fi,
+        out CommandError? error)
+    {
+        var boundary = ms.ModelSystem.GlobalBoundary;
+        // Wire caller → entryNode.
+        Assert.IsTrue(ms.AddLink(user, caller, callerHook, entryNode,
+            out _, out error), error?.Message);
+        // Wire entryNode → externalDest (when hook is provided).
+        if (entryHook is not null)
+        {
+            Assert.IsTrue(ms.AddLink(user, entryNode, entryHook, externalDest,
+                out _, out error), error?.Message);
+        }
+        return ms.ExtractToFunctionTemplate(
+            user, boundary,
+            new[] { entryNode },
+            "MyTemplate", "MyInstance",
+            FtLoc, FiLoc,
+            out ft, out fi, out error);
+    }
+
+    // ── Validation failures ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_EmptySelection_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_EmptySelection_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new Node[0],
+                    "T", "FI", FtLoc, FiLoc,
+                    out _, out _, out var error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_NoExternalIncomingLink_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_NoExternalIncomingLink_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Node", typeof(SimpleTestModule),
+                    EntryLoc, out var node, out var error), error?.Message);
+                // No link pointing to node from outside.
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { node! },
+                    "T", "FI", FtLoc, FiLoc,
+                    out _, out _, out error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_MultipleExternalIncomingLinks_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_MultipleExternalIncomingLinks_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                // entryNode: IgnoreResult<string> (IAction)
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                // Two callers pointing to entryNode.
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start1",
+                    CallerLoc, out var start1, out error), error?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start2",
+                    new Rectangle(0, 80, 160, 60), out var start2, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start1,
+                    TestHelper.GetHook(start1.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start2,
+                    TestHelper.GetHook(start2.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode! },
+                    "T", "FI", FtLoc, FiLoc,
+                    out _, out _, out error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_DuplicateTemplateName_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_DuplicateTemplateName_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                // Pre-create a template with the same name.
+                Assert.IsTrue(ms.AddFunctionTemplate(user, boundary, "MyTemplate",
+                    out _, out var error), error?.Message);
+
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(SimpleTestModule),
+                    EntryLoc, out var entry, out error), error?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entry,
+                    out _, out error), error?.Message);
+
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entry! },
+                    "MyTemplate", "FI", FtLoc, FiLoc,
+                    out _, out _, out error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    // ── Basic extraction (no external outgoing links) ─────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_Basic_Succeeds()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_Basic_Succeeds),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(SimpleTestModule),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                // Wire start → entryNode.
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode! },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out var fi, out error), error?.Message);
+
+                Assert.IsNotNull(ft);
+                Assert.IsNotNull(fi);
+
+                // The template should contain entryNode.
+                Assert.HasCount(1, ft!.InternalModules.Modules,
+                    "entryNode must be moved into InternalModules.");
+                Assert.AreSame(entryNode, ft.InternalModules.Modules[0]);
+
+                // Entry node is designated.
+                Assert.AreSame(entryNode, ft.EntryNode);
+
+                // No FunctionParameters (no external outgoing links).
+                Assert.IsEmpty(ft.FunctionParameters);
+
+                // FunctionInstance is in the boundary.
+                Assert.HasCount(1, boundary.FunctionInstances);
+                Assert.AreSame(fi, boundary.FunctionInstances[0]);
+
+                // entryNode must have left the boundary.
+                Assert.IsFalse(boundary.Modules.Contains(entryNode),
+                    "entryNode must no longer be in the parent boundary.");
+
+                // The incoming link (start → fi) must be in place.
+                var incomingLink = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == start && l.Destination == fi);
+                Assert.IsNotNull(incomingLink,
+                    "start must now link to the FunctionInstance.");
+            });
+    }
+
+    // ── Extraction with external outgoing link (creates FunctionParameter) ─
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_WithFunctionParameter_Succeeds()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_WithFunctionParameter_Succeeds),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                // Graph: start → entryNode (IgnoreResult<string>) → externalDest (SimpleTestModule)
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, entryNode,
+                    TestHelper.GetHook(entryNode!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out var fi, out error), error?.Message);
+
+                // ── Verify FunctionTemplate internals ──────────────────────
+                Assert.HasCount(1, ft!.InternalModules.Modules,
+                    "entryNode should be in InternalModules.");
+                Assert.AreSame(entryNode, ft.InternalModules.Modules[0]);
+                Assert.AreSame(entryNode, ft.EntryNode);
+
+                // One FunctionParameter for "To Ignore".
+                Assert.HasCount(1, ft.FunctionParameters);
+                var fp = ft.FunctionParameters[0];
+                Assert.AreEqual("To Ignore", fp.Name);
+
+                // Internal link: entryNode → fp (inside InternalModules).
+                var internalLink = ft.InternalModules.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == entryNode && l.Destination == fp);
+                Assert.IsNotNull(internalLink,
+                    "InternalModules must have a link from entryNode to the FunctionParameter.");
+
+                // ── Verify parent boundary ─────────────────────────────────
+                // entryNode gone from parent.
+                Assert.IsFalse(boundary.Modules.Contains(entryNode),
+                    "entryNode must be in InternalModules, not the parent boundary.");
+
+                // externalDest stays in parent.
+                Assert.IsTrue(boundary.Modules.Contains(externalDest!),
+                    "externalDest must remain in the parent boundary.");
+
+                // start → fi link.
+                var toFi = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == start && l.Destination == fi);
+                Assert.IsNotNull(toFi, "start must link to FunctionInstance.");
+
+                // fi → externalDest link via the FunctionParameterHook.
+                var fiLink = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == fi
+                        && l.OriginHook is FunctionParameterHook fph
+                        && ReferenceEquals(fph.Parameter, fp)
+                        && l.Destination == externalDest);
+                Assert.IsNotNull(fiLink,
+                    "FunctionInstance must link to externalDest via the FunctionParameterHook.");
+            });
+    }
+
+    // ── Multi-node extraction with internal link ───────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_MultipleNodes_InternalLinkPreserved()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_MultipleNodes_InternalLinkPreserved),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+
+                // Graph: start → nodeA (IgnoreResult<string>) → nodeB (IgnoreResult<string>) → externalDest
+                Assert.IsTrue(ms.AddNode(user, boundary, "NodeA", typeof(IgnoreResult<string>),
+                    EntryLoc, out var nodeA, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "NodeB", typeof(IgnoreResult<string>),
+                    new Rectangle(300, 0, 160, 60), out var nodeB, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error3), error3?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+
+                // start → nodeA
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), nodeA,
+                    out _, out error), error?.Message);
+                // nodeA → nodeB (internal link to move into InternalModules)
+                Assert.IsTrue(ms.AddLink(user, nodeA,
+                    TestHelper.GetHook(nodeA!.Hooks, "To Ignore"), nodeB,
+                    out _, out error), error?.Message);
+                // nodeB → externalDest (external outgoing, becomes FP)
+                Assert.IsTrue(ms.AddLink(user, nodeB,
+                    TestHelper.GetHook(nodeB!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { nodeA, nodeB },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out var fi, out error), error?.Message);
+
+                // Both nodes in InternalModules.
+                Assert.HasCount(2, ft!.InternalModules.Modules,
+                    "Both nodeA and nodeB must be in InternalModules.");
+
+                // Internal link nodeA → nodeB is preserved inside InternalModules.
+                var internalAB = ft.InternalModules.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == nodeA && l.Destination == nodeB);
+                Assert.IsNotNull(internalAB,
+                    "The nodeA→nodeB link must have moved into InternalModules.");
+
+                // One FP for nodeB's "To Ignore" hook → externalDest.
+                Assert.HasCount(1, ft.FunctionParameters);
+                var fp = ft.FunctionParameters[0];
+
+                // Internal link nodeB → fp.
+                var internalBFP = ft.InternalModules.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == nodeB && l.Destination == fp);
+                Assert.IsNotNull(internalBFP,
+                    "nodeB must link to the FunctionParameter inside InternalModules.");
+
+                // Parent boundary has start→fi and fi→externalDest.
+                Assert.HasCount(2, boundary.Links,
+                    "Boundary must have exactly start→fi and fi→externalDest links.");
+
+                var toExternal = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == fi && l.Destination == externalDest);
+                Assert.IsNotNull(toExternal,
+                    "FunctionInstance must link to externalDest.");
+            });
+    }
+
+    // ── Entry node is set correctly ────────────────────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_EntryNodeSetToIncomingLinkDestination()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_EntryNodeSetToIncomingLinkDestination),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(SimpleTestModule),
+                    EntryLoc, out var entry, out var error), error?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entry,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entry! },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out _, out error), error?.Message);
+
+                Assert.AreSame(entry, ft!.EntryNode,
+                    "The entry node must be the destination of the original external incoming link.");
+            });
+    }
+
+    // ── Undo/Redo ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_Undo_RestoresOriginalGraph()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_Undo_RestoresOriginalGraph),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                // start → entryNode → externalDest
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, entryNode,
+                    TestHelper.GetHook(entryNode!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                // Perform extraction.
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out _, out _, out error), error?.Message);
+
+                // State after extraction.
+                Assert.HasCount(1, boundary.FunctionTemplates);
+                Assert.HasCount(1, boundary.FunctionInstances);
+                Assert.IsFalse(boundary.Modules.Contains(entryNode));
+
+                // Undo.
+                Assert.IsTrue(ms.Undo(user, out error), error?.Message);
+
+                // State restored: no FT, no FI.
+                Assert.IsEmpty(boundary.FunctionTemplates,
+                    "Undo must remove the FunctionTemplate.");
+                Assert.IsEmpty(boundary.FunctionInstances,
+                    "Undo must remove the FunctionInstance.");
+
+                // entryNode is back in the boundary.
+                Assert.IsTrue(boundary.Modules.Contains(entryNode),
+                    "entryNode must be back in the parent boundary.");
+                Assert.AreSame(boundary, entryNode.ContainedWithin,
+                    "entryNode.ContainedWithin must point to the parent boundary again.");
+
+                // Original links are restored: start→entryNode and entryNode→externalDest.
+                var startLink = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == start && l.Destination == entryNode);
+                Assert.IsNotNull(startLink,
+                    "start→entryNode link must be restored after undo.");
+
+                var entryLink = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == entryNode && l.Destination == externalDest);
+                Assert.IsNotNull(entryLink,
+                    "entryNode→externalDest link must be restored after undo.");
+
+                // No extra links.
+                Assert.HasCount(2, boundary.Links,
+                    "Boundary must have exactly the two original links after undo.");
+            });
+    }
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_UndoRedo_ReappliesExtraction()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_UndoRedo_ReappliesExtraction),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, entryNode,
+                    TestHelper.GetHook(entryNode!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out _, out var fi, out error), error?.Message);
+
+                // Undo → Redo.
+                Assert.IsTrue(ms.Undo(user, out error), error?.Message);
+                Assert.IsTrue(ms.Redo(user, out error), error?.Message);
+
+                // After redo: FT and FI are back.
+                Assert.HasCount(1, boundary.FunctionTemplates,
+                    "Redo must restore the FunctionTemplate.");
+                Assert.HasCount(1, boundary.FunctionInstances,
+                    "Redo must restore the FunctionInstance.");
+
+                // entryNode back in InternalModules.
+                var ft = boundary.FunctionTemplates[0];
+                Assert.IsTrue(ft.InternalModules.Modules.Contains(entryNode),
+                    "entryNode must be back in InternalModules after redo.");
+
+                // start → fi link.
+                var toFi = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == start && l.Destination == fi);
+                Assert.IsNotNull(toFi, "start→fi link must be present after redo.");
+
+                // fi → externalDest link.
+                var toExt = boundary.Links
+                    .OfType<SingleLink>()
+                    .FirstOrDefault(l => l.Origin == fi && l.Destination == externalDest);
+                Assert.IsNotNull(toExt, "fi→externalDest link must be present after redo.");
+            });
+    }
+
+    // ── FunctionInstance hooks match FunctionParameters ────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_FunctionInstanceExposesHookPerParameter()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_FunctionInstanceExposesHookPerParameter),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, entryNode,
+                    TestHelper.GetHook(entryNode!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out var fi, out error), error?.Message);
+
+                // FI should expose exactly one FunctionParameterHook.
+                Assert.HasCount(1, fi!.Hooks,
+                    "FunctionInstance must expose one hook per FunctionParameter.");
+                Assert.IsInstanceOfType<FunctionParameterHook>(fi.Hooks[0],
+                    "The hook must be a FunctionParameterHook.");
+
+                var fph = (FunctionParameterHook)fi.Hooks[0];
+                Assert.AreSame(ft!.FunctionParameters[0], fph.Parameter,
+                    "The FunctionParameterHook must reference the correct FunctionParameter.");
+            });
+    }
+
+    // ── FunctionTemplate name uniqueness check ─────────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_BlankTemplateName_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_BlankTemplateName_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(SimpleTestModule),
+                    EntryLoc, out var entry, out var error), error?.Message);
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entry! },
+                    "   ", "FI", FtLoc, FiLoc,
+                    out _, out _, out error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_BlankInstanceName_Fails()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_BlankInstanceName_Fails),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(SimpleTestModule),
+                    EntryLoc, out var entry, out var error), error?.Message);
+                Assert.IsFalse(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entry! },
+                    "T", "   ", FtLoc, FiLoc,
+                    out _, out _, out error));
+                Assert.IsNotNull(error);
+            });
+    }
+
+    // ── Boundary counts after extraction ──────────────────────────────────
+
+    [TestMethod]
+    public void ExtractToFunctionTemplate_BoundaryCountsAreCorrect()
+    {
+        TestHelper.RunInModelSystemContext(
+            nameof(ExtractToFunctionTemplate_BoundaryCountsAreCorrect),
+            (user, pSess, ms) =>
+            {
+                var boundary = ms.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(ms.AddNode(user, boundary, "Entry", typeof(IgnoreResult<string>),
+                    EntryLoc, out var entryNode, out var error), error?.Message);
+                Assert.IsTrue(ms.AddNode(user, boundary, "ExternalDest", typeof(SimpleTestModule),
+                    ExtDestLoc, out var externalDest, out var error2), error2?.Message);
+                Assert.IsTrue(ms.AddModelSystemStart(user, boundary, "Start",
+                    CallerLoc, out var start, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, start,
+                    TestHelper.GetHook(start.Hooks, "ToExecute"), entryNode,
+                    out _, out error), error?.Message);
+                Assert.IsTrue(ms.AddLink(user, entryNode,
+                    TestHelper.GetHook(entryNode!.Hooks, "To Ignore"), externalDest,
+                    out _, out error), error?.Message);
+
+                Assert.IsTrue(ms.ExtractToFunctionTemplate(
+                    user, boundary, new[] { entryNode },
+                    "MyTemplate", "MyInstance",
+                    FtLoc, FiLoc,
+                    out var ft, out _, out error), error?.Message);
+
+                // Parent boundary: externalDest node only (entryNode moved to InternalModules).
+                Assert.HasCount(1, boundary.Modules,
+                    "Only externalDest must remain in the parent boundary.");
+                Assert.AreSame(externalDest, boundary.Modules[0]);
+
+                // Two links: start→fi and fi→externalDest.
+                Assert.HasCount(2, boundary.Links);
+
+                // One FunctionTemplate, one FunctionInstance.
+                Assert.HasCount(1, boundary.FunctionTemplates);
+                Assert.HasCount(1, boundary.FunctionInstances);
+                Assert.AreSame(ft, boundary.FunctionTemplates[0]);
+            });
+    }
+}


### PR DESCRIPTION
This PR adds the UX to allow the user to construct a function template in-place by selecting multiple modules and then either using the context menu or the keyboard shortcut ctrl+shift+m to both
create a new FunctionTemplate and a new instance of that type in-place, so links that were going to and or from it are automatically hooked up.  Only one entry link going to the selected
nodes are allowed.  Links leaving the selected nodes will be changed into FunctionParmaeters and automatically hooked up.
