### PR TITLE
Allow links to point to either side of NodeHook

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -72,6 +72,20 @@ public sealed partial class ModelSystemCanvas : Control
     /// <summary>Tracks which FunctionParameterHooks on each FunctionInstance have live links.</summary>
     private readonly Dictionary<FunctionInstanceViewModel, HashSet<FunctionParameterHook>> _fiConnectedHooks = new();
 
+    /// <summary>
+    /// Per-frame set of (node, hook) pairs where at least one link departs leftward
+    /// (destination centre X is to the left of the origin node's left edge).
+    /// Used to render a dot on the left face and to choose the correct exit anchor.
+    /// Rebuilt each frame by <see cref="BuildHookAnchorCache"/>.
+    /// </summary>
+    private readonly HashSet<(NodeViewModel, NodeHook)> _leftGoingHooks = new();
+
+    /// <summary>
+    /// Per-frame set of (fi, hook) pairs for FunctionInstance hooks where at least one
+    /// link departs leftward.  Rebuilt each frame by <see cref="BuildHookAnchorCache"/>.
+    /// </summary>
+    private readonly HashSet<(FunctionInstanceViewModel, FunctionParameterHook)> _leftGoingFiHooks = new();
+
     // ── Inline parameter editor ───────────────────────────────────────────
     /// <summary>Overlay TextBox used for in-canvas parameter value editing.</summary>
     private readonly TextBox _inlineEditor;

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Geometry.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Geometry.cs
@@ -46,15 +46,18 @@ partial class ModelSystemCanvas
         if (link.Origin is NodeViewModel originNvm
             && _hookAnchors.TryGetValue((originNvm, link.UnderlyingLink.OriginHook), out var hookPt))
         {
-            p1 = hookPt;
-            exitDir = new Vector(1, 0); // hooks always face right
+            // Exit from the left face when the destination centre is to the left of the node.
+            bool goLeft = destCenter.X < originNvm.X;
+            p1 = goLeft ? new Point(originNvm.X, hookPt.Y) : hookPt;
+            exitDir = goLeft ? new Vector(-1, 0) : new Vector(1, 0);
         }
         else if (link.Origin is FunctionInstanceViewModel fiOriginSC
             && link.UnderlyingLink.OriginHook is FunctionParameterHook fphSC
             && _fiHookAnchors.TryGetValue((fiOriginSC, fphSC), out var fiHookPtSC))
         {
-            p1 = fiHookPtSC;
-            exitDir = new Vector(1, 0); // FP hook dots always face right
+            bool goLeft = destCenter.X < fiOriginSC.X;
+            p1 = goLeft ? new Point(fiOriginSC.X, fiHookPtSC.Y) : fiHookPtSC;
+            exitDir = goLeft ? new Vector(-1, 0) : new Vector(1, 0);
         }
         else if (link.Origin is StartViewModel startOrigin)
         {
@@ -94,14 +97,22 @@ partial class ModelSystemCanvas
     {
         var destCenter = new Point(link.X2, link.Y2);
 
+        var destCenterO = new Point(link.X2, link.Y2);
+
         if (link.Origin is NodeViewModel originNvm
             && _hookAnchors.TryGetValue((originNvm, link.UnderlyingLink.OriginHook), out var hookPt))
-            return hookPt;
+        {
+            bool goLeft = destCenterO.X < originNvm.X;
+            return goLeft ? new Point(originNvm.X, hookPt.Y) : hookPt;
+        }
 
         if (link.Origin is FunctionInstanceViewModel fiOriginO
             && link.UnderlyingLink.OriginHook is FunctionParameterHook fphO
             && _fiHookAnchors.TryGetValue((fiOriginO, fphO), out var fiHookPtO))
-            return fiHookPtO;
+        {
+            bool goLeft = destCenterO.X < fiOriginO.X;
+            return goLeft ? new Point(fiOriginO.X, fiHookPtO.Y) : fiHookPtO;
+        }
 
         if (link.Origin is StartViewModel startOriginO)
         {

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.HitTesting.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.HitTesting.cs
@@ -162,6 +162,8 @@ partial class ModelSystemCanvas
         _canInlineNodes.Clear();
         _fiHookAnchors.Clear();
         _fiConnectedHooks.Clear();
+        _leftGoingHooks.Clear();
+        _leftGoingFiHooks.Clear();
         if (_vm is null) return;
 
         // Which hooks on each node have a live link?
@@ -172,6 +174,11 @@ partial class ModelSystemCanvas
                 if (!_nodeConnectedHooks.TryGetValue(originVm, out var set))
                     _nodeConnectedHooks[originVm] = set = new HashSet<NodeHook>();
                 set.Add(link.UnderlyingLink.OriginHook);
+
+                // Track hooks whose link destination lies to the left of the origin node.
+                // Such links will exit from the node's left face rather than the right.
+                if (link.Destination is not null && link.X2 < originVm.X)
+                    _leftGoingHooks.Add((originVm, link.UnderlyingLink.OriginHook));
             }
             // Which FunctionParameterHooks on each FI have a live link?
             if (link.Origin is FunctionInstanceViewModel fiOriginVm
@@ -180,6 +187,10 @@ partial class ModelSystemCanvas
                 if (!_fiConnectedHooks.TryGetValue(fiOriginVm, out var fiSet))
                     _fiConnectedHooks[fiOriginVm] = fiSet = new HashSet<FunctionParameterHook>();
                 fiSet.Add(fphConnected);
+
+                // Same leftward check for FunctionInstance hooks.
+                if (link.Destination is not null && link.X2 < fiOriginVm.X)
+                    _leftGoingFiHooks.Add((fiOriginVm, fphConnected));
             }
         }
 

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Rendering.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Rendering.cs
@@ -420,6 +420,14 @@ partial class ModelSystemCanvas
                 ctx.DrawEllipse(dotBrush, null,
                     new Point(fi.X + rw, dotCy), HookDotRadius, HookDotRadius);
 
+                // When at least one link from this FI hook departs leftward, also draw a dot
+                // on the left edge so the visual anchor matches the link exit point.
+                if (fpHook is not null && _leftGoingFiHooks.Contains((fi, fpHook)))
+                {
+                    ctx.DrawEllipse(dotBrush, null,
+                        new Point(fi.X, dotCy), HookDotRadius, HookDotRadius);
+                }
+
                 // Label: prefix with ≡ (BasicParameter) or ƒ (ScriptedParameter) when inlined.
                 const double textPad = 6.0;
                 string hookLabel = hasInlinedFi && inlinedFiParam is not null
@@ -1006,6 +1014,15 @@ partial class ModelSystemCanvas
                 ctx.DrawEllipse(dotBrush, null,
                     new Point(node.X + rw, rowMidY),
                     HookDotRadius, HookDotRadius);
+
+                // When at least one link from this hook departs leftward, also draw a dot
+                // on the left edge so the visual anchor matches the link exit point.
+                if (_leftGoingHooks.Contains((node, hook)))
+                {
+                    ctx.DrawEllipse(dotBrush, null,
+                        new Point(node.X, rowMidY),
+                        HookDotRadius, HookDotRadius);
+                }
 
                 // Hook name + optional inlined value.
                 // When a param is inlined, prefix with ≡ (BasicParameter) or ƒ (ScriptedParameter).


### PR DESCRIPTION
Currently links can only originate to the right hand side of a NodeHook, this patch allows them to start from either side.