### PR TITLE
FunctionParameter fixes

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
@@ -529,9 +529,9 @@ partial class ModelSystemCanvas
             };
 
             var removeItem = new MenuItem { Header = "Remove Function Parameter" };
-            removeItem.Click += async (_, _) =>
+            removeItem.Click += (_, _) =>
             {
-                await vm.RemoveFunctionParameterAsync(fpvm.UnderlyingParameter);
+                vm.RemoveFunctionParameterAsync(fpvm.UnderlyingParameter);
                 InvalidateAndMeasure();
             };
             menu.Items.Add(new Separator());

--- a/src/XTMF2.GUI/ViewModels/DiffTreeItem.cs
+++ b/src/XTMF2.GUI/ViewModels/DiffTreeItem.cs
@@ -297,6 +297,16 @@ public sealed class DiffFunctionTemplateItem
             }
         }
 
+        foreach (var fp in diff.FunctionParameters)
+        {
+            if (showUnchanged || fp.Kind != ElementDiffKind.Unchanged)
+            {
+                var item = new DiffElementItem(fp);
+                if (!hasFilter || item.MatchesFilter(filter!))
+                    children.Add(item);
+            }
+        }
+
         Children = children;
     }
     
@@ -441,6 +451,32 @@ public sealed class DiffElementItem
         ElementId = fi.Id;
     }
 
+    /// <summary>Constructs a display item from a <see cref="FunctionParameterDiff"/>.</summary>
+    internal DiffElementItem(FunctionParameterDiff fp)
+    {
+        Kind = fp.Kind;
+        TypeTag = "FunctionParameter";
+        Label = fp.DisplayName;
+        if (fp.Kind != ElementDiffKind.Modified)
+        {
+            ChangeDescription = null;
+        }
+        else
+        {
+            var parts = new List<string>(3);
+            if (fp.LeftName != fp.RightName)
+                parts.Add($"\"{ fp.LeftName}\" \u2192 \"{fp.RightName}\"");
+            if (fp.LeftType != fp.RightType)
+                parts.Add($"type: {ShortTypeName(fp.LeftType)} \u2192 {ShortTypeName(fp.RightType)}");
+            if (fp.LeftLocation is Rectangle fpL && fp.RightLocation is Rectangle fpR
+                && fpL != Rectangle.Hidden && fpR != Rectangle.Hidden && fpL != fpR)
+                parts.Add("moved");
+            ChangeDescription = parts.Count > 0 ? string.Join("; ", parts) : null;
+        }
+        Tooltip = BuildFunctionParameterTooltip(fp);
+        ElementId = fp.Id;
+    }
+
     // ── Tooltip helpers ───────────────────────────────────────────────────
 
     private static string? BuildNodeTooltip(NodeDiff node, string typeTag)
@@ -567,6 +603,46 @@ public sealed class DiffElementItem
             if (fi.LeftLocation is Rectangle fiL && fi.RightLocation is Rectangle fiR
                 && fiL != Rectangle.Hidden && fiR != Rectangle.Hidden && fiL != fiR)
                 sb.Append($"\nMoved: ({fiL.X},{fiL.Y}) \u2192 ({fiR.X},{fiR.Y})");
+        }
+        return sb.ToString();
+    }
+
+    private static string? BuildFunctionParameterTooltip(FunctionParameterDiff fp)
+    {
+        if (fp.Kind == ElementDiffKind.Unchanged) return null;
+
+        var kindLabel = fp.Kind switch
+        {
+            ElementDiffKind.Added   => "Added",
+            ElementDiffKind.Removed => "Removed",
+            _                       => "Modified"
+        };
+        var sb = new StringBuilder();
+        sb.Append($"{kindLabel} FunctionParameter: \"{fp.DisplayName}\"");
+
+        if (fp.Kind == ElementDiffKind.Added)
+        {
+            if (fp.RightType is not null)
+                sb.Append($"\nType: {ShortTypeName(fp.RightType)}");
+            if (fp.RightLocation is Rectangle fpRAdd && fpRAdd != Rectangle.Hidden)
+                sb.Append($"\nLocation: ({fpRAdd.X},{fpRAdd.Y})");
+        }
+        else if (fp.Kind == ElementDiffKind.Removed)
+        {
+            if (fp.LeftType is not null)
+                sb.Append($"\nType: {ShortTypeName(fp.LeftType)}");
+            if (fp.LeftLocation is Rectangle fpLRem && fpLRem != Rectangle.Hidden)
+                sb.Append($"\nLocation: ({fpLRem.X},{fpLRem.Y})");
+        }
+        else
+        {
+            if (fp.LeftName != fp.RightName)
+                sb.Append($"\nName: \"{fp.LeftName}\" \u2192 \"{fp.RightName}\"");
+            if (fp.LeftType != fp.RightType)
+                sb.Append($"\nType: {ShortTypeName(fp.LeftType)} \u2192 {ShortTypeName(fp.RightType)}");
+            if (fp.LeftLocation is Rectangle fpL && fp.RightLocation is Rectangle fpR
+                && fpL != Rectangle.Hidden && fpR != Rectangle.Hidden && fpL != fpR)
+                sb.Append($"\nMoved: ({fpL.X},{fpL.Y}) \u2192 ({fpR.X},{fpR.Y})");
         }
         return sb.ToString();
     }

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -2519,13 +2519,17 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
             await ShowError("Rename Function Parameter Failed", error);
     }
 
-    public async Task RemoveFunctionParameterAsync(FunctionParameter parameter)
+    public bool RemoveFunctionParameterAsync(FunctionParameter parameter)
     {
-        if (_currentFunctionTemplate is null) return;
+        if (_currentFunctionTemplate is null) return false;
 
         if (!Session.RemoveFunctionParameter(
                 User, _currentFunctionTemplate.UnderlyingTemplate, parameter, out var error))
-            await ShowError("Remove Function Parameter Failed", error);
+        {
+            ShowToast(error?.Message ?? "Failed to remove function parameter.", isError: true, durationMs: 4000);
+            return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -3039,18 +3043,20 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
             CommandError? err = null;
             bool ok = el switch
             {
-                NodeViewModel         nvm => Session.RemoveNode(User, nvm.UnderlyingNode, out err),
-                StartViewModel        svm => Session.RemoveStart(User, svm.UnderlyingStart, out err),
-                CommentBlockViewModel cvm => Session.RemoveCommentBlock(User, _currentBoundary, cvm.UnderlyingBlock, out err),
+                NodeViewModel         nvm  => Session.RemoveNode(User, nvm.UnderlyingNode, out err),
+                StartViewModel        svm  => Session.RemoveStart(User, svm.UnderlyingStart, out err),
+                CommentBlockViewModel cvm  => Session.RemoveCommentBlock(User, _currentBoundary, cvm.UnderlyingBlock, out err),
                 FunctionTemplateViewModel ftvm => Session.RemoveFunctionTemplate(User, _currentBoundary, ftvm.UnderlyingTemplate, out err),
-                _                        => true,
+                FunctionParameterViewModel fpvm when _currentFunctionTemplate is not null
+                    => Session.RemoveFunctionParameter(User, _currentFunctionTemplate.UnderlyingTemplate, fpvm.UnderlyingParameter, out err),
+                _  => true,
             };
             if (!ok && err is not null)
                 firstError ??= err;
         }
 
         if (firstError is not null)
-            await ShowError("Delete Failed", firstError);
+            ShowToast(firstError.Message ?? "Delete failed.", isError: true, durationMs: 4000);
     }
 
     /// <summary>Delete whichever element or link is currently selected.</summary>
@@ -3087,6 +3093,13 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
             await DeleteFunctionInstanceAsync(fivm);
             return;
         }
+        else if (SelectedElement is FunctionParameterViewModel fpvm
+                 && _currentFunctionTemplate is not null)
+        {
+            SelectElement(null);
+            success = Session.RemoveFunctionParameter(
+                User, _currentFunctionTemplate.UnderlyingTemplate, fpvm.UnderlyingParameter, out error);
+        }
         else if (SelectedElement is GhostNodeViewModel ghostVm)
         {
             SelectElement(null);
@@ -3114,7 +3127,7 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         done:
 
         if (!success && error is not null)
-            await ShowError("Delete Failed", error);
+            ShowToast(error.Message ?? "Delete failed.", isError: true, durationMs: 4000);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/XTMF2/Diff/DiffResult.cs
+++ b/src/XTMF2/Diff/DiffResult.cs
@@ -268,6 +268,48 @@ public sealed class ModelSystemDiff
     }
 }
 
+/// <summary>Represents the diff of a single <see cref="FunctionParameter"/> within a function template.</summary>
+public sealed class FunctionParameterDiff
+{
+    /// <summary>The stable GUID of this function parameter.</summary>
+    public Guid Id { get; }
+
+    public ElementDiffKind Kind { get; }
+
+    /// <summary>Parameter name in the left model system, or null if not present.</summary>
+    public string? LeftName { get; }
+    /// <summary>Parameter name in the right model system, or null if not present.</summary>
+    public string? RightName { get; }
+
+    /// <summary>Assembly-qualified type name in the left model system, or null if not present.</summary>
+    public string? LeftType { get; }
+    /// <summary>Assembly-qualified type name in the right model system, or null if not present.</summary>
+    public string? RightType { get; }
+
+    /// <summary>Canvas position in the left model system (null when not present on that side).</summary>
+    public Rectangle? LeftLocation { get; }
+    /// <summary>Canvas position in the right model system (null when not present on that side).</summary>
+    public Rectangle? RightLocation { get; }
+
+    public FunctionParameterDiff(Guid id, ElementDiffKind kind,
+        string? leftName, string? rightName,
+        string? leftType, string? rightType,
+        Rectangle? leftLocation = null, Rectangle? rightLocation = null)
+    {
+        Id = id;
+        Kind = kind;
+        LeftName = leftName;
+        RightName = rightName;
+        LeftType = leftType;
+        RightType = rightType;
+        LeftLocation = leftLocation;
+        RightLocation = rightLocation;
+    }
+
+    /// <summary>Human-readable display name using the available side's name.</summary>
+    public string DisplayName => RightName ?? LeftName ?? Id.ToString("N")[..8];
+}
+
 /// <summary>
 /// Represents the diff of an entire function template (recursive) between two model systems.
 /// </summary>
@@ -288,10 +330,14 @@ public sealed class FunctionTemplateDiff
 
     public BoundaryDiff SubBoundary { get; }
 
+    /// <summary>Diffs for each <see cref="FunctionParameter"/> within this template.</summary>
+    public IReadOnlyList<FunctionParameterDiff> FunctionParameters { get; }
+
     public FunctionTemplateDiff(Guid id, ElementDiffKind kind,
         string? leftName, string? rightName,
         Rectangle? leftLocation, Rectangle? rightLocation,
-        BoundaryDiff subBoundary)
+        BoundaryDiff subBoundary,
+        IReadOnlyList<FunctionParameterDiff>? functionParameters = null)
     {
         Id = id;
         Kind = kind;
@@ -300,16 +346,19 @@ public sealed class FunctionTemplateDiff
         LeftLocation = leftLocation;
         RightLocation = rightLocation;
         SubBoundary = subBoundary;
+        FunctionParameters = functionParameters ?? Array.Empty<FunctionParameterDiff>();
     }
 
     /// <summary>Human-readable boundary name for display.</summary>
     public string DisplayName => RightName ?? LeftName ?? "(unnamed)";
 
-    /// <summary>True if this function template has changes (name, location, or internal content).</summary>
+    /// <summary>True if this function template has changes (name, location, internal content, or function parameters).</summary>
     public bool HasChanges => Kind != ElementDiffKind.Unchanged;
 
-    /// <summary>Count of directly-changed elements within this boundary (excluding sub-boundaries).</summary>
-    public int DirectChangeCount => SubBoundary.DirectChangeCount;
+    /// <summary>Count of directly-changed elements within this template (including function parameters).</summary>
+    public int DirectChangeCount =>
+        SubBoundary.DirectChangeCount +
+        FunctionParameters.Count(fp => fp.Kind != ElementDiffKind.Unchanged);
 }
 
 /// <summary>Represents the diff of a single <see cref="FunctionInstance"/> between two model systems.</summary>

--- a/src/XTMF2/Diff/ModelSystemComparer.cs
+++ b/src/XTMF2/Diff/ModelSystemComparer.cs
@@ -335,6 +335,7 @@ public static class ModelSystemComparer
             if (rightById.TryGetValue(id, out var right))
             {
                 var subBoundary = CompareBoundary(left.InternalModules, right.InternalModules);
+                var functionParameters = CompareFunctionParameters(left.FunctionParameters, right.FunctionParameters);
 
                 // All element types inside InternalModules — including Starts — have stable
                 // persisted GUIDs, so we can safely include them in the changed check.
@@ -347,13 +348,14 @@ public static class ModelSystemComparer
                     || subBoundary.CommentBlocks.Any(c => c.Kind != ElementDiffKind.Unchanged)
                     || subBoundary.FunctionInstances.Any(fi => fi.Kind != ElementDiffKind.Unchanged)
                     || subBoundary.FunctionTemplates.Any(ft => ft.HasChanges)
-                    || subBoundary.SubBoundaries.Any(b => b.HasChanges);
+                    || subBoundary.SubBoundaries.Any(b => b.HasChanges)
+                    || functionParameters.Any(fp => fp.Kind != ElementDiffKind.Unchanged);
 
                 result.Add(new FunctionTemplateDiff(id,
                     contentChanged ? ElementDiffKind.Modified : ElementDiffKind.Unchanged,
                     left.Name, right.Name,
                     left.Location, right.Location,
-                    subBoundary));
+                    subBoundary, functionParameters));
             }
             else
                 result.Add(FunctionTemplateRemoved(left));
@@ -368,15 +370,65 @@ public static class ModelSystemComparer
         return result;
     }
 
+    private static IReadOnlyList<FunctionParameterDiff> CompareFunctionParameters(
+        IEnumerable<FunctionParameter> leftParams, IEnumerable<FunctionParameter> rightParams)
+    {
+        var leftById  = leftParams.ToDictionary(fp => fp.Id);
+        var rightById = rightParams.ToDictionary(fp => fp.Id);
+        var result    = new List<FunctionParameterDiff>();
+
+        foreach (var (id, left) in leftById)
+        {
+            if (rightById.TryGetValue(id, out var right))
+            {
+                bool locationChanged = left.Location != right.Location
+                    && left.Location != Rectangle.Hidden
+                    && right.Location != Rectangle.Hidden;
+                bool changed = left.Name != right.Name || left.Type != right.Type || locationChanged;
+                result.Add(new FunctionParameterDiff(id,
+                    changed ? ElementDiffKind.Modified : ElementDiffKind.Unchanged,
+                    left.Name, right.Name,
+                    left.Type?.AssemblyQualifiedName, right.Type?.AssemblyQualifiedName,
+                    left.Location, right.Location));
+            }
+            else
+            {
+                result.Add(new FunctionParameterDiff(id, ElementDiffKind.Removed,
+                    left.Name, null,
+                    left.Type?.AssemblyQualifiedName, null,
+                    left.Location, null));
+            }
+        }
+
+        foreach (var (id, right) in rightById)
+        {
+            if (!leftById.ContainsKey(id))
+            {
+                result.Add(new FunctionParameterDiff(id, ElementDiffKind.Added,
+                    null, right.Name,
+                    null, right.Type?.AssemblyQualifiedName,
+                    null, right.Location));
+            }
+        }
+
+        return result;
+    }
+
     private static FunctionTemplateDiff FunctionTemplateAdded(FunctionTemplate ft) => new FunctionTemplateDiff(
         ft.Id, ElementDiffKind.Added, null, ft.Name,
         null, ft.Location,
-        BoundaryAdded(ft.InternalModules));
+        BoundaryAdded(ft.InternalModules),
+        ft.FunctionParameters.Select(fp => new FunctionParameterDiff(fp.Id, ElementDiffKind.Added,
+            null, fp.Name, null, fp.Type?.AssemblyQualifiedName,
+            null, fp.Location)).ToList());
 
     private static FunctionTemplateDiff FunctionTemplateRemoved(FunctionTemplate ft) => new FunctionTemplateDiff(
         ft.Id, ElementDiffKind.Removed, ft.Name, null,
         ft.Location, null,
-        BoundaryRemoved(ft.InternalModules));
+        BoundaryRemoved(ft.InternalModules),
+        ft.FunctionParameters.Select(fp => new FunctionParameterDiff(fp.Id, ElementDiffKind.Removed,
+            fp.Name, null, fp.Type?.AssemblyQualifiedName, null,
+            fp.Location, null)).ToList());
 
     // ── FunctionInstance comparison ────────────────────────────────────────
 


### PR DESCRIPTION
Function parameters currently don't notify changes in their locations for difference.  This PR fixes that.  Additionally deleting a function parameter was not giving the user feedback if it didn't succeed.  Now a toast notifcation is sent if we are unable to delete them.
