### PR TITLE
Fix small rendering errors when editing model system

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -949,6 +949,17 @@ partial class ModelSystemCanvas
             return;
         }
 
+        // ── Left-button release: end element resize ──────────────────────
+        if (_resizing is not null)
+        {
+            _resizing.CommitResize();
+            _resizing = null;
+            e.Pointer.Capture(null);
+            InvalidateAndMeasure();
+            e.Handled = true;
+            return;
+        }
+
         // ── Left-button release: end element drag ─────────────────────────
         if (_dragging is null) return;
         if (_vm is null) return;

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Rendering.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Rendering.cs
@@ -676,6 +676,22 @@ partial class ModelSystemCanvas
             // or whose destination node is inlined (value shown in hook row instead).
             if (link.Destination is null) continue;
             if (link.Destination is NodeViewModel destNvm && destNvm.IsInlined) continue;
+            
+            // Check if the destination's underlying model belongs to the current boundary.
+            // Using ContainedWithin (rather than collection membership) keeps undo working:
+            // after an undo the boundary manager creates a fresh ViewModel for the returned
+            // node, so the stale VM in link.Destination is no longer in the Nodes collection
+            // but its UnderlyingNode.ContainedWithin is updated back to the current boundary.
+            bool destinationInCurrentView = link.Destination switch
+            {
+                NodeViewModel nvm            => nvm.UnderlyingNode.ContainedWithin            == _vm.CurrentBoundary,
+                StartViewModel svm           => svm.UnderlyingStart.ContainedWithin           == _vm.CurrentBoundary,
+                GhostNodeViewModel gvm       => gvm.UnderlyingGhostNode.ContainedWithin       == _vm.CurrentBoundary,
+                FunctionInstanceViewModel fivm => fivm.UnderlyingInstance.ContainedWithin     == _vm.CurrentBoundary,
+                FunctionParameterViewModel fpvm => fpvm.UnderlyingParameter.ContainedWithin   == _vm.CurrentBoundary,
+                _ => false
+            };
+            if (!destinationInCurrentView) continue;
 
             bool isDisabled = link.UnderlyingLink.IsDisabled;
             var brush = link.IsSelected

--- a/src/XTMF2.GUI/Views/TypePickerDialog.axaml.cs
+++ b/src/XTMF2.GUI/Views/TypePickerDialog.axaml.cs
@@ -276,6 +276,10 @@ public partial class TypePickerDialog : Window, INotifyPropertyChanged
                 {
                     TypeListBox.SelectedIndex = idx;
                     TypeListBox.ScrollIntoView(TypeListBox.SelectedItem!);
+                    // Explicitly call OnListSelectionChanged to ensure CanOK is updated.
+                    // This is needed because if the item is already at the selected index,
+                    // SelectionChanged won't fire.
+                    OnListSelectionChanged();
                 }
             }
         };
@@ -357,6 +361,7 @@ public partial class TypePickerDialog : Window, INotifyPropertyChanged
 
         FilteredTypes = new ObservableCollection<Type>(source);
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasNoResults)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanOK)));
 
         // Keep the list box in sync — auto-select first match.
         if (FilteredTypes.Count > 0)


### PR DESCRIPTION
1. When moving nodes between Boundaries it is currently still rendering links going to the last position of the node.  Now the link is no longer rendered.
2. The OK button in the Type Selection Dialog is now enabled as long as there is an option when openned.  Previously it was only updated when the index was changed for the listbox.
3. Resizing comments now works and renders correctly.
