### PR TITLE
Add Button to Open Module that caused error

### DIFF
--- a/src/XTMF2.GUI/RunController.cs
+++ b/src/XTMF2.GUI/RunController.cs
@@ -106,7 +106,7 @@ public class RunController : IDisposable
         };
         hostBus.ClientReportedStatus += controller.OnClientReportedStatus;
         hostBus.ClientFinishedModelSystem += controller.OnClientFinishedModelSystem;
-        hostBus.ClientErrorWhenRunningModelSystem += controller.OnClientErrorWhenRunningModelSystem;
+        hostBus.ClientErrorWhenRunningModelSystemWithTarget += controller.OnClientErrorWhenRunningModelSystem;
         hostBus.ClientOptimizationResultsAvailable += controller.OnClientOptimizationResultsAvailable;
         hostBus.ClientIterationProgressAvailable += controller.OnClientIterationProgressAvailable;
         // Start the client processing in a separate thread to avoid blocking the GUI
@@ -153,7 +153,7 @@ public class RunController : IDisposable
             controller = new RunController(runtime, hostBus);
             hostBus.ClientReportedStatus += controller.OnClientReportedStatus;
             hostBus.ClientFinishedModelSystem += controller.OnClientFinishedModelSystem;
-            hostBus.ClientErrorWhenRunningModelSystem += controller.OnClientErrorWhenRunningModelSystem;
+            hostBus.ClientErrorWhenRunningModelSystemWithTarget += controller.OnClientErrorWhenRunningModelSystem;
             hostBus.ClientOptimizationResultsAvailable += controller.OnClientOptimizationResultsAvailable;
             hostBus.ClientIterationProgressAvailable += controller.OnClientIterationProgressAvailable;
             return true;
@@ -166,9 +166,9 @@ public class RunController : IDisposable
         }
     }
 
-    private void OnClientErrorWhenRunningModelSystem(object sender, string runID, string errorMessage, string stack)
+    private void OnClientErrorWhenRunningModelSystem(object sender, string runID, string errorMessage, string stack, string? moduleName, Guid? elementId)
     {
-        RunsViewModel.NotifyError(runID, errorMessage, stack);
+        RunsViewModel.NotifyError(runID, errorMessage, stack, moduleName, elementId);
     }
 
     private void OnClientFinishedModelSystem(object? sender, string runID)
@@ -271,7 +271,7 @@ public class RunController : IDisposable
         {
             _sessionsByRunId[id] = (msSession, user);
         }
-        var vm = RunsViewModel.AddRun(id, runName);
+        var vm = RunsViewModel.AddRun(id, runName, msSession, user);
         if (runMode != RunMode.Normal)
         {
             // Extract parameter metadata so the progress dialog can show names/bounds.

--- a/src/XTMF2.GUI/ViewModels/RunViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/RunViewModel.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using XTMF2.Configuration;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using XTMF2.Bus;
@@ -76,11 +77,42 @@ public sealed partial class RunViewModel : ObservableObject
         _                  => "?"
     };
 
-    public RunViewModel(string runId, string runName)
+    private readonly ModelSystemSession _session;
+    private readonly User _user;
+
+    public RunViewModel(string runId, string runName, ModelSystemSession session, User user)
     {
         RunId   = runId;
         RunName = runName;
+        _session = session;
+        _user = user;
     }
+
+    /// <summary>
+    /// The resolved failing module name for the current error, if available.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ErrorNavigationLinkText))]
+    private string? _errorModuleName;
+
+    /// <summary>
+    /// The canvas element ID (node/function instance/etc.) associated with the current error.
+    /// </summary>
+    private Guid? _errorElementId;
+
+    /// <summary>
+    /// True when this run error includes a navigable model element target.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasErrorNavigationTarget;
+
+    /// <summary>
+    /// Link text shown in the Runs view for navigating to the failing module.
+    /// </summary>
+    public string ErrorNavigationLinkText =>
+        string.IsNullOrWhiteSpace(ErrorModuleName)
+            ? "Open failing module"
+            : $"Open failing module: {ErrorModuleName}";
 
     // ── Optimization run support ──────────────────────────────────────────
 
@@ -236,16 +268,35 @@ public sealed partial class RunViewModel : ObservableObject
     }
 
     /// <summary>Marks the run as failed with an error message.</summary>
-    internal void MarkError(string errorMessage, string stack)
+    internal void MarkError(string errorMessage, string stack, string? moduleName, Guid? elementId)
     {
         Status     = RunStatus.Error;
         StatusText = errorMessage;
+        ErrorModuleName = moduleName;
+        _errorElementId = elementId;
+        HasErrorNavigationTarget = elementId.HasValue;
         if (!string.IsNullOrEmpty(stack))
             Messages.Add($"Stack trace:\n{stack}");
         Messages.Add($"Error: {errorMessage}");
+        if (!string.IsNullOrWhiteSpace(moduleName))
+            Messages.Add($"Failing module: {moduleName}");
         OnPropertyChanged(nameof(StatusBadge));
         OnPropertyChanged(nameof(IsCompleted));
         CancelRunCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Returns navigation context for the current failing element, when available.
+    /// </summary>
+    internal bool TryGetErrorNavigationTarget(out ModelSystemSession session, out User user, out Guid elementId)
+    {
+        session = _session;
+        user = _user;
+        elementId = Guid.Empty;
+        if (!_errorElementId.HasValue)
+            return false;
+        elementId = _errorElementId.Value;
+        return true;
     }
 
     /// <summary>True when the run has finished or errored (i.e. it is safe to remove).</summary>

--- a/src/XTMF2.GUI/ViewModels/RunsViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/RunsViewModel.cs
@@ -57,9 +57,9 @@ public sealed partial class RunsViewModel : ObservableObject
     /// <param name="runId">The ID assigned by the host bus.</param>
     /// <param name="runName">The human-readable run name.</param>
     /// <returns>The newly created <see cref="RunViewModel"/>.</returns>
-    internal RunViewModel AddRun(string runId, string runName)
+    internal RunViewModel AddRun(string runId, string runName, ModelSystemSession session, User user)
     {
-        var vm = new RunViewModel(runId, runName);
+        var vm = new RunViewModel(runId, runName, session, user);
         Dispatcher.UIThread.Post(() =>
         {
             Runs.Add(vm);
@@ -85,13 +85,13 @@ public sealed partial class RunsViewModel : ObservableObject
     /// <summary>
     /// Marks the run with <paramref name="runId"/> as failed.  Safe to call from any thread.
     /// </summary>
-    internal void NotifyError(string runId, string errorMessage, string stack)
+    internal void NotifyError(string runId, string errorMessage, string stack, string? moduleName, Guid? elementId)
     {
         var vm = FindRun(runId);
         if (vm is null) return;
         Dispatcher.UIThread.Post(() =>
         {
-            vm.MarkError(errorMessage, stack);
+            vm.MarkError(errorMessage, stack, moduleName, elementId);
             SystemAlert.ShowRunFailed(vm.RunName);
         });
     }

--- a/src/XTMF2.GUI/Views/RunsView.axaml
+++ b/src/XTMF2.GUI/Views/RunsView.axaml
@@ -104,6 +104,13 @@
                                        Opacity="0.7"
                                        VerticalAlignment="Center"/>
                         </StackPanel>
+                        <Button Content="{Binding SelectedRun.ErrorNavigationLinkText}"
+                            IsVisible="{Binding SelectedRun.HasErrorNavigationTarget}"
+                            Classes="dlg-primary"
+                            Margin="0,6,0,0"
+                            HorizontalAlignment="Left"
+                            Click="OpenErrorTargetButton_Click"
+                            ToolTip.Tip="Open this run's model system and focus the element that raised the error."/>
                         <!-- Apply optimization results button — only visible after estimation/calibration runs -->
                         <Button Content="⬇  Apply Optimization Results to Model System"
                                 Command="{Binding SelectedRun.ApplyOptimizationResultsCommand}"

--- a/src/XTMF2.GUI/Views/RunsView.axaml.cs
+++ b/src/XTMF2.GUI/Views/RunsView.axaml.cs
@@ -20,6 +20,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using XTMF2.GUI;
 using XTMF2.GUI.ViewModels;
 
 namespace XTMF2.GUI.Views;
@@ -71,5 +72,19 @@ public partial class RunsView : UserControl
             window.Show(owner);
         else
             window.Show();
+    }
+
+    private void OpenErrorTargetButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_vm?.SelectedRun is not { } run) return;
+        if (!run.TryGetErrorNavigationTarget(out var session, out var user, out var elementId))
+            return;
+
+        if (TopLevel.GetTopLevel(this) is not MainWindow mainWindow)
+            return;
+
+        var editor = mainWindow.OpenModelSystemTabAndGet(session, user);
+        mainWindow.FocusEditorTab(editor);
+        editor.NavigateToElementById(elementId);
     }
 }

--- a/src/XTMF2/Bus/HostBus.cs
+++ b/src/XTMF2/Bus/HostBus.cs
@@ -112,7 +112,15 @@ public sealed class HostBus : IDisposable
     /// <param name="runID">The ID of the run that failed.</param>
     /// <param name="errorMessage">The error message from the error.</param>
     /// <param name="stack">The stack trace at the point of the error.</param>
-    public delegate void RunError(object sender, string runID, string errorMessage, string stack);
+    /// <param name="moduleName">The name of the module that caused the error, if known.</param>
+    /// <param name="elementId">The model element ID (Node/FunctionInstance/etc.) associated with the failure, if it could be resolved from the failing runtime module.</param>
+    public delegate void RunError(object sender, string runID, string errorMessage, string stack, string? moduleName, Guid? elementId);
+
+    /// <summary>
+    /// Used to report that a model system has had a run error, including optional
+    /// module metadata for UI navigation.
+    /// </summary>
+    public delegate void RunErrorWithTarget(object sender, string runID, string errorMessage, string stack, string? moduleName, Guid? elementId);
 
     /// <summary>
     /// Used to trigger a status update from a model system.
@@ -126,6 +134,12 @@ public sealed class HostBus : IDisposable
     /// This event is signalled when a client runs into an error.
     /// </summary>
     public event RunError? ClientErrorWhenRunningModelSystem;
+
+    /// <summary>
+    /// This event is signalled when a client runs into an error and includes
+    /// optional model-element metadata.
+    /// </summary>
+    public event RunErrorWithTarget? ClientErrorWhenRunningModelSystemWithTarget;
 
     /// <summary>
     /// This event is triggered when the client has sent an update for the run's status message.
@@ -209,7 +223,10 @@ public sealed class HostBus : IDisposable
                             {
                                 var runId = reader.ReadString();
                                 var errMsg = reader.ReadString();
-                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystem?.Invoke(this, runId, errMsg, String.Empty));
+                                var moduleName = reader.ReadString();
+                                var elementId = Guid.TryParse(reader.ReadString(), out var parsedId) ? (Guid?)parsedId : null;
+                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystem?.Invoke(this, runId, errMsg, String.Empty, moduleName, elementId));
+                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystemWithTarget?.Invoke(this, runId, errMsg, String.Empty, moduleName, elementId));
                             }
                             break;
                         case In.ClientFinishedModelSystem:
@@ -223,7 +240,13 @@ public sealed class HostBus : IDisposable
                                 var runId = reader.ReadString();
                                 var errMsg = reader.ReadString();
                                 var stack = reader.ReadString();
-                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystem?.Invoke(this, runId, errMsg, stack));
+                                var moduleName = reader.ReadString();
+                                var elementIdText = reader.ReadString();
+                                var elementId = Guid.TryParse(elementIdText, out var parsedId)
+                                    ? (Guid?)parsedId
+                                    : null;
+                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystem?.Invoke(this, runId, errMsg, stack, moduleName, elementId));
+                                IgnoreWarnings(() => ClientErrorWhenRunningModelSystemWithTarget?.Invoke(this, runId, errMsg, stack, moduleName, elementId));
                             }
                             break;
                         case In.ClientReportedStatus:

--- a/src/XTMF2/Bus/Run.cs
+++ b/src/XTMF2/Bus/Run.cs
@@ -119,9 +119,8 @@ namespace XTMF2.Bus
         /// </summary>
         /// <param name="error">An error message if the model system is invalid.</param>
         /// <returns>True if the model system is valid, false otherwise with an error message.</returns>
-        private bool ValidateModelSystem(ref string? error)
+        private bool ValidateModelSystem(ref string? error, ref string? moduleName, ref Guid? elementId)
         {
-            string? moduleName = null;
             // Make sure that we are able to actually construct the directory
             try
             {
@@ -140,7 +139,7 @@ namespace XTMF2.Bus
             }
             if (!ModelSystem.Load(modelSystemAsString, _runtime, out var ms, ref error)
                 || !ms!.Construct(_runtime, ref error)
-                || !ms!.Validate(ref moduleName, ref error))
+                || !ms!.Validate(ref moduleName, ref error, ref elementId))
             {
                 RunResults.WriteValidationError(_currentWorkingDirectory, moduleName, "Failed when validating the model system! " + error + "\r\n" + modelSystemAsString);
                 return false;
@@ -222,20 +221,21 @@ namespace XTMF2.Bus
         public RunError? StartRun()
         {
             string? error = null, moduleName = null, stackTrace = string.Empty;
+            Guid? elementId = null;
             var runBus = _runtime.RunBus;
             if (runBus is not null)
                 runBus.CurrentRun = this;
-            if (!ValidateModelSystem(ref error))
+            if (!ValidateModelSystem(ref error, ref moduleName, ref elementId))
             {
-                return new RunError(RunErrorType.Validation, $"Failed when validating the model system! {error}", moduleName, stackTrace);
+                return new RunError(RunErrorType.Validation, $"Failed when validating the model system! {error}", moduleName, stackTrace, elementId);
             }
             if(!GetStart(Start.ParseStartString(StartToExecute), out var startingMss, ref error))
             {
-                return new RunError(RunErrorType.Validation, $"Failed when getting the start point! {error}", moduleName, stackTrace);
+                return new RunError(RunErrorType.Validation, $"Failed when getting the start point! {error}", moduleName, stackTrace, elementId);
             }
             if(startingMss == null)
             {
-                return new RunError(RunErrorType.Validation, "Unable to find the starting point for this run!", moduleName, stackTrace);
+                return new RunError(RunErrorType.Validation, "Unable to find the starting point for this run!", moduleName, stackTrace, elementId);
             }
             var originalDir = Directory.GetCurrentDirectory();
             try
@@ -268,8 +268,17 @@ namespace XTMF2.Bus
                 error = e.Message;
                 stackTrace = e.StackTrace;
                 RunResults.WriteError(_currentWorkingDirectory, e);
-                return new RunError(RunErrorType.Runtime, error, 
-                    e is XTMFRuntimeException xtmfError ? xtmfError.FailingModule?.Name ?? "Unknown module" : null, stackTrace);
+                elementId = null;
+                string? failingModuleName = null;
+                if (e is XTMFRuntimeException xtmfError)
+                {
+                    if (!TryResolveModelElementForRuntimeModule(_modelSystem, xtmfError.FailingModule,
+                        out failingModuleName, out elementId))
+                    {
+                        failingModuleName = xtmfError.FailingModule?.Name ?? "Unknown module";
+                    }
+                }
+                return new RunError(RunErrorType.Runtime, error, failingModuleName, stackTrace, elementId);
             }
             finally
             {
@@ -279,6 +288,84 @@ namespace XTMF2.Bus
             }
             // success for now
             return null;
+        }
+
+        /// <summary>
+        /// Attempts to map a failing runtime module instance back to a model element
+        /// that is visible on the canvas.
+        /// </summary>
+        internal static bool TryResolveModelElementForRuntimeModule(
+            ModelSystem? modelSystem,
+            IModule? failingModule,
+            out string? moduleName,
+            out Guid? elementId)
+        {
+            moduleName = null;
+            elementId = null;
+            if (modelSystem is null || failingModule is null)
+                return false;
+
+            var toProcess = new Stack<Boundary>();
+            toProcess.Push(modelSystem.GlobalBoundary);
+            while (toProcess.TryPop(out var boundary))
+            {
+                foreach (var child in boundary.Boundaries)
+                    toProcess.Push(child);
+
+                foreach (var start in boundary.Starts)
+                {
+                    if (ReferenceEquals(start.Module, failingModule))
+                    {
+                        moduleName = start.Name;
+                        elementId = start.Id;
+                        return true;
+                    }
+                }
+
+                foreach (var node in boundary.Modules)
+                {
+                    if (ReferenceEquals(node.Module, failingModule))
+                    {
+                        moduleName = node.Name;
+                        elementId = node.Id;
+                        return true;
+                    }
+                }
+
+                foreach (var fi in boundary.FunctionInstances)
+                {
+                    if (ReferenceEquals(fi.Module, failingModule))
+                    {
+                        moduleName = fi.Name;
+                        elementId = fi.Id;
+                        return true;
+                    }
+
+                    // Runtime failures from internal template modules are surfaced on the
+                    // function-instance canvas element because internals are not visible at
+                    // the boundary scope where the instance is placed.
+                    foreach (var internalStart in fi.Template.InternalModules.Starts)
+                    {
+                        if (ReferenceEquals(fi.GetRuntimeModule(internalStart), failingModule))
+                        {
+                            moduleName = fi.Name;
+                            elementId = fi.Id;
+                            return true;
+                        }
+                    }
+                    foreach (var internalNode in fi.Template.InternalModules.Modules)
+                    {
+                        if (ReferenceEquals(fi.GetRuntimeModule(internalNode), failingModule))
+                        {
+                            moduleName = fi.Name;
+                            elementId = fi.Id;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
 
         private bool RuntimeValidation(ref string? moduleName, ref string? errorMessage)

--- a/src/XTMF2/Bus/RunBus.cs
+++ b/src/XTMF2/Bus/RunBus.cs
@@ -109,13 +109,15 @@ namespace XTMF2.Bus
         /// Signal to the host that the run failed in the validation step.
         /// </summary>
         /// <param name="error">The error message.</param>
-        internal void ModelRunFailedValidation(string? error)
+        internal void ModelRunFailedValidation(string? error, string? moduleName, Guid? elementId)
         {
             Write((writer) =>
             {
                 writer.Write((int)Out.ClientErrorValidatingModelSystem);
                 writer.Write(_id);
                 writer.Write(error ?? "No error message!");
+                writer.Write(moduleName ?? String.Empty);
+                writer.Write(elementId?.ToString() ?? String.Empty);
             });
         }
 
@@ -124,7 +126,9 @@ namespace XTMF2.Bus
         /// </summary>
         /// <param name="message">The message containing the error.</param>
         /// <param name="stackTrace">The stack trace from the time of the error.</param>
-        internal void ModelRunFailed(string? message, string? stackTrace)
+        /// <param name="moduleName">The resolved module name, when available.</param>
+        /// <param name="elementId">The resolved model element ID, when available.</param>
+        internal void ModelRunFailed(string? message, string? stackTrace, string? moduleName = null, Guid? elementId = null)
         {
             Write((writer) =>
             {
@@ -132,6 +136,8 @@ namespace XTMF2.Bus
                 writer.Write(_id);
                 writer.Write(message ?? String.Empty);
                 writer.Write(stackTrace ?? String.Empty);
+                writer.Write(moduleName ?? String.Empty);
+                writer.Write(elementId?.ToString() ?? String.Empty);
             });
         }
 
@@ -207,13 +213,13 @@ namespace XTMF2.Bus
                                     switch (error?.Type)
                                     {
                                         case RunErrorType.Validation:
-                                            ModelRunFailedValidation(error.Message);
+                                            ModelRunFailedValidation(error.Message, error.ModuleName, error.ElementId);
                                             break;
                                         case RunErrorType.RuntimeValidation:
-                                            ModelRunFailedValidation(error.Message);
+                                            ModelRunFailedValidation(error.Message, error.ModuleName, error.ElementId);
                                             break;
                                         case RunErrorType.Runtime:
-                                            ModelRunFailed(error.Message, error.StackTrace);
+                                            ModelRunFailed(error.Message, error.StackTrace, error.ModuleName, error.ElementId);
                                             break;
                                         default:
                                             ModelRunComplete();

--- a/src/XTMF2/Bus/RunContext.cs
+++ b/src/XTMF2/Bus/RunContext.cs
@@ -225,10 +225,10 @@ namespace XTMF2.Bus
                 {
                     case RunErrorType.Validation:
                     case RunErrorType.RuntimeValidation:
-                        runBus.ModelRunFailedValidation(error.Message);
+                        runBus.ModelRunFailedValidation(error.Message, error.ModuleName, error.ElementId);
                         break;
                     case RunErrorType.Runtime:
-                        runBus.ModelRunFailed(error.Message, error.StackTrace);
+                        runBus.ModelRunFailed(error.Message, error.StackTrace, error.ModuleName, error.ElementId);
                         break;
                     default:
                         runBus.ModelRunComplete();
@@ -261,7 +261,7 @@ namespace XTMF2.Bus
                 if (buildError!.Type is RunErrorType.Validation or RunErrorType.RuntimeValidation)
                     client.ModelRunFailedValidation(ID, buildError.Message ?? "Estimation setup failed");
                 else
-                    client.ModelRunFailed(ID, buildError.Message, buildError.StackTrace);
+                    client.ModelRunFailed(ID, buildError.Message, buildError.StackTrace, buildError.ModuleName, buildError.ElementId?.ToString());
                 return;
             }
 
@@ -341,8 +341,14 @@ namespace XTMF2.Bus
                         catch (Exception e)
                         {
                             while (e.InnerException is Exception inner) e = inner;
-                            firstRunError = new RunError(RunErrorType.Runtime, e.Message,
-                                e is XTMFRuntimeException xe ? xe.FailingModule?.Name : null, e.StackTrace);
+                            Guid? elementId = null;
+                            string? moduleName = null;
+                            if (e is XTMFRuntimeException xe)
+                            {
+                                if (!Run.TryResolveModelElementForRuntimeModule(ms, xe.FailingModule, out moduleName, out elementId))
+                                    moduleName = xe.FailingModule?.Name;
+                            }
+                            firstRunError = new RunError(RunErrorType.Runtime, e.Message, moduleName, e.StackTrace, elementId);
                             return double.MaxValue;
                         }
                         latestValues = (double[])values.Clone();
@@ -363,7 +369,15 @@ namespace XTMF2.Bus
             }
             catch (Exception ex)
             {
-                client.ModelRunFailed(ID, ex.Message, ex.StackTrace);
+                string? moduleName = null;
+                string? elementId = null;
+                if (ex is XTMFRuntimeException xe)
+                {
+                    if (!Run.TryResolveModelElementForRuntimeModule(ms, xe.FailingModule, out moduleName, out var resolvedElementId))
+                        moduleName = xe.FailingModule?.Name;
+                    elementId = resolvedElementId?.ToString();
+                }
+                client.ModelRunFailed(ID, ex.Message, ex.StackTrace, moduleName, elementId);
                 return;
             }
             finally
@@ -378,7 +392,7 @@ namespace XTMF2.Bus
                 if (firstRunError.Type is RunErrorType.Validation or RunErrorType.RuntimeValidation)
                     client.ModelRunFailedValidation(ID, firstRunError.Message ?? "Unknown validation error");
                 else
-                    client.ModelRunFailed(ID, firstRunError.Message, firstRunError.StackTrace);
+                    client.ModelRunFailed(ID, firstRunError.Message, firstRunError.StackTrace, firstRunError.ModuleName, firstRunError.ElementId?.ToString());
                 return;
             }
 
@@ -407,7 +421,7 @@ namespace XTMF2.Bus
                 if (buildError!.Type is RunErrorType.Validation or RunErrorType.RuntimeValidation)
                     client.ModelRunFailedValidation(ID, buildError.Message ?? "Calibration setup failed");
                 else
-                    client.ModelRunFailed(ID, buildError.Message, buildError.StackTrace);
+                    client.ModelRunFailed(ID, buildError.Message, buildError.StackTrace, buildError.ModuleName, buildError.ElementId?.ToString());
                 return;
             }
 
@@ -472,7 +486,15 @@ namespace XTMF2.Bus
                     catch (Exception e)
                     {
                         while (e.InnerException is Exception inner) e = inner;
-                        client.ModelRunFailed(ID, e.Message, e.StackTrace);
+                        string? moduleName = null;
+                        string? elementId = null;
+                        if (e is XTMFRuntimeException xe)
+                        {
+                            if (!Run.TryResolveModelElementForRuntimeModule(ms, xe.FailingModule, out moduleName, out var resolvedElementId))
+                                moduleName = xe.FailingModule?.Name;
+                            elementId = resolvedElementId?.ToString();
+                        }
+                        client.ModelRunFailed(ID, e.Message, e.StackTrace, moduleName, elementId);
                         return;
                     }
 
@@ -542,6 +564,7 @@ namespace XTMF2.Bus
         {
             ms = null; start = null;
             string? errorMsg = null, moduleName = null;
+            Guid? elementId = null;
 
             try { Directory.CreateDirectory(_currentWorkingDirectory); }
             catch (IOException e)
@@ -559,10 +582,10 @@ namespace XTMF2.Bus
 
             if (!ModelSystem.Load(msString, _runtime, out ms, ref errorMsg)
                 || !ms!.Construct(_runtime, ref errorMsg)
-                || !ms!.Validate(ref moduleName, ref errorMsg))
+                || !ms!.Validate(ref moduleName, ref errorMsg, ref elementId))
             {
                 error = new RunError(RunErrorType.Validation,
-                    errorMsg ?? "Failed to build model system.", moduleName, string.Empty);
+                    errorMsg ?? "Failed to build model system.", moduleName, string.Empty, elementId);
                 return false;
             }
 
@@ -573,11 +596,11 @@ namespace XTMF2.Bus
                 return false;
             }
 
-            if (!RuntimeValidateAll(ms, ref moduleName, ref errorMsg))
+            if (!RuntimeValidateAll(ms, ref moduleName, ref errorMsg, ref elementId))
             {
                 RunResults.WriteValidationError(_currentWorkingDirectory, moduleName, errorMsg);
                 error = new RunError(RunErrorType.RuntimeValidation,
-                    errorMsg ?? "Runtime validation failed.", moduleName, string.Empty);
+                    errorMsg ?? "Runtime validation failed.", moduleName, string.Empty, elementId);
                 return false;
             }
 
@@ -618,7 +641,7 @@ namespace XTMF2.Bus
         }
 
         private static bool RuntimeValidateAll(
-            ModelSystem ms, ref string? moduleName, ref string? errorMessage)
+            ModelSystem ms, ref string? moduleName, ref string? errorMessage, ref Guid? elementId)
         {
             var toProcess = new Stack<Boundary>();
             toProcess.Push(ms.GlobalBoundary);
@@ -633,15 +656,15 @@ namespace XTMF2.Bus
                         try
                         {
                             if (!realModule.RuntimeValidation(ref errorMessage))
-                            { moduleName = module.Name; return false; }
+                            { moduleName = module.Name; elementId = module.Id; return false; }
                         }
                         catch (Exception e)
-                        { moduleName = module.Name; errorMessage = e.Message; return false; }
+                        { moduleName = module.Name; elementId = module.Id; errorMessage = e.Message; return false; }
                     }
                 }
                 foreach (var fi in current.FunctionInstances)
                 {
-                    if (!fi.ValidateRuntimeModules(ref moduleName, ref errorMessage))
+                    if (!fi.ValidateRuntimeModules(ref moduleName, ref errorMessage, ref elementId))
                         return false;
                 }
             }

--- a/src/XTMF2/Bus/RunError.cs
+++ b/src/XTMF2/Bus/RunError.cs
@@ -27,12 +27,13 @@ namespace XTMF2.Bus
     /// </summary>
     public sealed class RunError
     {
-        public RunError(RunErrorType type, string? message, string? moduleName, string? stackTrace)
+        public RunError(RunErrorType type, string? message, string? moduleName, string? stackTrace, Guid? elementId = null)
         {
             Type = type;
             Message = message;
             ModuleName = moduleName;
             StackTrace = stackTrace;
+            ElementId = elementId;
         }
 
         /// <summary>
@@ -50,6 +51,12 @@ namespace XTMF2.Bus
         /// A description of the error that occurred.
         /// </summary>
         public string? Message {get; private set;}
+
+        /// <summary>
+        /// The model element ID (Node/FunctionInstance/etc.) associated with the failure,
+        /// if it could be resolved from the failing runtime module.
+        /// </summary>
+        public Guid? ElementId { get; private set; }
 
         /// <summary>
         /// The stack trace for the error.

--- a/src/XTMF2/Bus/RunServerBus.cs
+++ b/src/XTMF2/Bus/RunServerBus.cs
@@ -146,10 +146,21 @@ namespace XTMF2.Bus
                                 WriteHeartbeat(reader.ReadString());
                                 break;
                             case Out.ClientErrorValidatingModelSystem:
-                                ModelRunFailedValidation(reader.ReadString(), reader.ReadString());
+                            {
+                                var runId = reader.ReadString();
+                                var error = reader.ReadString();
+                                var moduleName = reader.ReadString();
+                                var elementId = reader.ReadString();
+                                ModelRunFailedValidation(runId,error, moduleName, elementId);
                                 return;
+                            }
                             case Out.ClientErrorWhenRunningModelSystem:
-                                ModelRunFailed(reader.ReadString(), reader.ReadString(), reader.ReadString());
+                                ModelRunFailed(
+                                    reader.ReadString(),
+                                    reader.ReadString(),
+                                    reader.ReadString(),
+                                    reader.ReadString(),
+                                    reader.ReadString());
                                 return;
                             case Out.ClientReportedStatus:
                                 SendStatusMessage(reader.ReadString(), reader.ReadString());
@@ -221,13 +232,15 @@ namespace XTMF2.Bus
         /// </summary>
         /// <param name="context">The run that failed.</param>
         /// <param name="error">The error message.</param>
-        internal void ModelRunFailedValidation(string runId, string error)
+        internal void ModelRunFailedValidation(string runId, string? error, string? moduleName = null, string? elementId = null)
         {
             Write((writer) =>
             {
                 writer.Write((int)Out.ClientErrorValidatingModelSystem);
                 writer.Write(runId);
                 writer.Write(error ?? "No error message!");
+                writer.Write(moduleName ?? String.Empty);
+                writer.Write(elementId ?? String.Empty);
             });
         }
 
@@ -237,7 +250,9 @@ namespace XTMF2.Bus
         /// <param name="context">The run that failed.</param>
         /// <param name="message">The message containing the error.</param>
         /// <param name="stackTrace">The stack trace from the time of the error.</param>
-        internal void ModelRunFailed(string runId, string? message, string? stackTrace)
+        /// <param name="moduleName">The resolved module name, when available.</param>
+        /// <param name="elementId">The resolved model element ID, when available.</param>
+        internal void ModelRunFailed(string runId, string? message, string? stackTrace, string? moduleName = null, string? elementId = null)
         {
             Write((writer) =>
             {
@@ -245,6 +260,8 @@ namespace XTMF2.Bus
                 writer.Write(runId);
                 writer.Write(message ?? String.Empty);
                 writer.Write(stackTrace ?? String.Empty);
+                writer.Write(moduleName ?? String.Empty);
+                writer.Write(elementId ?? String.Empty);
             });
         }
 

--- a/src/XTMF2/Bus/Scheduler.cs
+++ b/src/XTMF2/Bus/Scheduler.cs
@@ -76,7 +76,7 @@ namespace XTMF2.Bus
                             }
                             catch (Exception e)
                             {
-                                _Bus.ModelRunFailed(context.ID, e.Message, e.StackTrace);
+                                _Bus.ModelRunFailed(context.ID, e.Message, e.StackTrace, null, null);
                             }
                         }
                     }

--- a/src/XTMF2/ModelSystemConstruct/Boundary.cs
+++ b/src/XTMF2/ModelSystemConstruct/Boundary.cs
@@ -167,16 +167,22 @@ namespace XTMF2.ModelSystemConstruct
 
         internal bool Validate(ref string? moduleName, ref string? error)
         {
+            Guid? elementId = null;
+            return Validate(ref moduleName, ref error, ref elementId);
+        }
+
+        internal bool Validate(ref string? moduleName, ref string? error, ref Guid? elementId)
+        {
             foreach (var module in _modules)
             {
-                if (!module.Validate(ref moduleName, ref error))
+                if (!module.Validate(ref moduleName, ref error, ref elementId))
                 {
                     return false;
                 }
             }
             foreach (var children in _boundaries)
             {
-                if (!children.Validate(ref moduleName, ref error))
+                if (!children.Validate(ref moduleName, ref error, ref elementId))
                 {
                     return false;
                 }
@@ -184,7 +190,7 @@ namespace XTMF2.ModelSystemConstruct
             // Validate the internal structure of each FunctionTemplate once (shared across all instances).
             foreach (var ft in _functionTemplates)
             {
-                if (!ft.InternalModules.Validate(ref moduleName, ref error))
+                if (!ft.InternalModules.Validate(ref moduleName, ref error, ref elementId))
                     return false;
             }
             return true;

--- a/src/XTMF2/ModelSystemConstruct/FunctionInstance.cs
+++ b/src/XTMF2/ModelSystemConstruct/FunctionInstance.cs
@@ -529,6 +529,12 @@ namespace XTMF2.ModelSystemConstruct
         /// </summary>
         internal bool ValidateRuntimeModules(ref string? moduleName, ref string? error)
         {
+            Guid? elementId = null;
+            return ValidateRuntimeModules(ref moduleName, ref error, ref elementId);
+        }
+
+        internal bool ValidateRuntimeModules(ref string? moduleName, ref string? error, ref Guid? elementId)
+        {
             if (_runtimeModules is null) { error = null; return true; }
             foreach (var (node, module) in _runtimeModules)
             {
@@ -537,12 +543,16 @@ namespace XTMF2.ModelSystemConstruct
                     if (!module.RuntimeValidation(ref error))
                     {
                         moduleName = Name + "." + node.Name;
+                        // Internal template nodes are not directly visible from the boundary;
+                        // navigate to the owning FunctionInstance on the canvas.
+                        elementId = Id;
                         return false;
                     }
                 }
                 catch (Exception e)
                 {
                     moduleName = Name + "." + node.Name;
+                    elementId = Id;
                     error = e.Message;
                     return false;
                 }

--- a/src/XTMF2/ModelSystemConstruct/ModelSystem.cs
+++ b/src/XTMF2/ModelSystemConstruct/ModelSystem.cs
@@ -255,6 +255,15 @@ namespace XTMF2
         }
 
         /// <summary>
+        /// Check that all requirements have been met when constructing the model system,
+        /// returning the failing element ID when available.
+        /// </summary>
+        internal bool Validate(ref string? moduleName, ref string? error, ref Guid? elementId)
+        {
+            return GlobalBoundary.Validate(ref moduleName, ref error, ref elementId);
+        }
+
+        /// <summary>
         /// Generate the concrete model system for execution.
         /// </summary>
         /// <param name="runtime">The XTMF run time that we are executing within.</param>

--- a/src/XTMF2/ModelSystemConstruct/Node.cs
+++ b/src/XTMF2/ModelSystemConstruct/Node.cs
@@ -211,6 +211,12 @@ namespace XTMF2.ModelSystemConstruct
 
         internal bool Validate(ref string? moduleName, ref string? error)
         {
+            Guid? elementId = null;
+            return Validate(ref moduleName, ref error, ref elementId);
+        }
+
+        internal bool Validate(ref string? moduleName, ref string? error, ref Guid? elementId)
+        {
             if (IsDisabled)
             {
                 return true;
@@ -224,6 +230,7 @@ namespace XTMF2.ModelSystemConstruct
                     if (!ContainedWithin.Links.Any(l => l.Origin == this && l.OriginHook == hook))
                     {
                         moduleName = Name;
+                        elementId = Id;
                         error = $"A required link was not assigned for the hook {hook.Name}!";
                         return false;
                     }

--- a/src/XTMF2/RunResults.cs
+++ b/src/XTMF2/RunResults.cs
@@ -1,5 +1,5 @@
 ﻿/*
-    Copyright 2020 University of Toronto
+    Copyright 2020-2026 University of Toronto
 
     This file is part of XTMF2.
 
@@ -56,6 +56,8 @@ namespace XTMF2
         public string? ErrorStackTrace { get; private set; }
 
         public string? ErrorModuleName { get; private set; }
+
+        public string? ErrorElementId { get; private set; }
 
         public string RunDirectory { get; private set; }
 
@@ -167,6 +169,8 @@ namespace XTMF2
             {
                 writer.WriteString(nameof(ErrorModuleName),
                     xtmfError.FailingModule?.Name ?? String.Empty);
+                
+                writer.WriteString(nameof(ErrorElementId), (xtmfError.FailingModule?.ToString()) ?? string.Empty);
             }
             writer.WriteEndObject();
         }
@@ -177,7 +181,7 @@ namespace XTMF2
         /// <param name="runDirectory">The directory that the run was executed in.</param>
         /// <param name="moduleName">The name of the module that had the error.</param>
         /// <param name="errorMessage">A description of the error.</param>
-        internal static void WriteValidationError(string runDirectory, string? moduleName, string? errorMessage)
+        internal static void WriteValidationError(string runDirectory, string? moduleName, string? errorMessage, Guid? elementId = null)
         {
             using var stream = File.OpenWrite(Path.Combine(runDirectory, ResultsFile));
             using var writer = new Utf8JsonWriter(stream);
@@ -186,6 +190,7 @@ namespace XTMF2
             writer.WriteString(nameof(ErrorMessage), errorMessage ?? string.Empty);           
             writer.WriteString(nameof(ErrorModuleName),
                 moduleName ?? string.Empty);
+            writer.WriteString(nameof(ErrorElementId), (elementId?.ToString()) ?? string.Empty);
             writer.WriteEndObject();
         }
     }

--- a/tests/XTMF2.UnitTests/Editing/TestFunctionTemplateVariables.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestFunctionTemplateVariables.cs
@@ -464,7 +464,7 @@ public class TestFunctionTemplateVariables
                     bool success = false;
                     using var sem = new SemaphoreSlim(0);
                     runBus.ClientFinishedModelSystem += (_, _) => { success = true; sem.Release(); };
-                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack, moduleName, elementId) =>
                     {
                         runError = new CommandError(e + "\r\n" + stack);
                         sem.Release();
@@ -528,7 +528,7 @@ public class TestFunctionTemplateVariables
                     bool success = false;
                     using var sem = new SemaphoreSlim(0);
                     runBus.ClientFinishedModelSystem += (_, _) => { success = true; sem.Release(); };
-                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack, moduleName, elementId) =>
                     {
                         runError = new CommandError(e + "\r\n" + stack);
                         sem.Release();
@@ -598,7 +598,7 @@ public class TestFunctionTemplateVariables
                     bool success = false;
                     using var sem = new SemaphoreSlim(0);
                     runBus.ClientFinishedModelSystem += (_, _) => { success = true; sem.Release(); };
-                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack, moduleName, elementId) =>
                     {
                         runError = new CommandError(e + "\r\n" + stack);
                         sem.Release();

--- a/tests/XTMF2.UnitTests/Editing/TestLinks.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestLinks.cs
@@ -708,7 +708,7 @@ namespace XTMF2.UnitTests.Editing
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();

--- a/tests/XTMF2.UnitTests/ModelSystemConstruct/TestFunctionInstanceToFunctionInstanceLink.cs
+++ b/tests/XTMF2.UnitTests/ModelSystemConstruct/TestFunctionInstanceToFunctionInstanceLink.cs
@@ -115,7 +115,7 @@ public class TestFunctionInstanceToFunctionInstanceLink
                         success = true;
                         sem.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (_, _, e, stack, moduleName, elementId) =>
                     {
                         runError = new CommandError(e + "\r\n" + stack);
                         sem.Release();

--- a/tests/XTMF2.UnitTests/TestOptimizationRun.cs
+++ b/tests/XTMF2.UnitTests/TestOptimizationRun.cs
@@ -86,7 +86,7 @@ public class TestOptimizationRun
                     success = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -157,7 +157,7 @@ public class TestOptimizationRun
                     success = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -223,7 +223,7 @@ public class TestOptimizationRun
                     finished = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -293,7 +293,7 @@ public class TestOptimizationRun
                     finished = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -370,7 +370,7 @@ public class TestOptimizationRun
                     finished = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -439,7 +439,7 @@ public class TestOptimizationRun
                     finished = true;
                     sim.Release();
                 };
-                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                 {
                     error = new CommandError(e + "\r\n" + stack);
                     sim.Release();
@@ -511,7 +511,7 @@ public class TestOptimizationRun
                         success = true;
                         sim.Release();
                     };
-                    HostBus.RunError onError = (sender, runId, e, stack) =>
+                    HostBus.RunError onError = (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();

--- a/tests/XTMF2.UnitTests/TestRun.cs
+++ b/tests/XTMF2.UnitTests/TestRun.cs
@@ -77,7 +77,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -118,7 +118,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -175,7 +175,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error2 = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -221,7 +221,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    clientBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    clientBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -266,7 +266,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -314,7 +314,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -362,7 +362,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();
@@ -410,7 +410,7 @@ namespace XTMF2.UnitTests
                         success = true;
                         sim.Release();
                     };
-                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack) =>
+                    runBus.ClientErrorWhenRunningModelSystem += (sender, runId, e, stack, moduleName, elementId) =>
                     {
                         error = new CommandError(e + "\r\n" + stack);
                         sim.Release();


### PR DESCRIPTION
Propagates the GUID of the module throwing an XTMFRuntimeException and allow the user to click a button in the GUI to open the model system to the module containing the error.