### PR TITLE
Fix copying comment blocks

### DIFF
--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -494,6 +494,38 @@ public sealed partial class ModelSystemCanvas : Control
         _vm = DataContext as ModelSystemEditorViewModel;
         Attach();
         InvalidateAndMeasure();
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            EnsureCanvasFocusAndSelection();
+        }, Avalonia.Threading.DispatcherPriority.Render);
+    }
+
+    protected override void OnGotFocus(GotFocusEventArgs e)
+    {
+        base.OnGotFocus(e);
+        EnsureCanvasFocusAndSelection();
+    }
+
+    private void EnsureCanvasFocusAndSelection()
+    {
+        if (_vm is null) return;
+
+        if (!IsFocused)
+            Focus();
+
+        if (_vm.SelectedElement is not null || _vm.SelectedLink is not null)
+            return;
+
+        ICanvasElement? first = _vm.Nodes.FirstOrDefault();
+        first ??= _vm.Starts.FirstOrDefault();
+        first ??= _vm.CommentBlocks.FirstOrDefault();
+        first ??= _vm.GhostNodes.FirstOrDefault();
+        first ??= _vm.FunctionTemplates.FirstOrDefault();
+        first ??= _vm.FunctionInstances.FirstOrDefault();
+        first ??= _vm.FunctionParameterVMs.FirstOrDefault();
+
+        if (first is not null)
+            _vm.SelectElementCommand.Execute(first);
     }
 
     private void Attach()
@@ -655,6 +687,11 @@ public sealed partial class ModelSystemCanvas : Control
         if (e.PropertyName is nameof(ModelSystemEditorViewModel.CurrentBoundary))
         {
             _lastCanvasMousePos = null;
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                EnsureCanvasFocusAndSelection();
+                InvalidateAndMeasure();
+            }, Avalonia.Threading.DispatcherPriority.Render);
         }
 
 

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -650,6 +650,13 @@ public sealed partial class ModelSystemCanvas : Control
             Avalonia.Threading.Dispatcher.UIThread.Post(InvalidateAndMeasure);
         }
 
+        // Boundary switches can leave the last cursor anchor in an unrelated coordinate space.
+        // Clearing it forces Ctrl+V to use the viewport-centre fallback in the new boundary.
+        if (e.PropertyName is nameof(ModelSystemEditorViewModel.CurrentBoundary))
+        {
+            _lastCanvasMousePos = null;
+        }
+
 
         // When we navigate into or out of a FunctionTemplate, maintain a direct subscription
         // to the template VM so that property changes (e.g. EntryNode after undo) still

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas.cs
@@ -496,6 +496,8 @@ public sealed partial class ModelSystemCanvas : Control
         InvalidateAndMeasure();
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
+            if (!IsKeyboardFocusWithin)
+                Focus();
             EnsureCanvasFocusAndSelection();
         }, Avalonia.Threading.DispatcherPriority.Render);
     }
@@ -503,15 +505,18 @@ public sealed partial class ModelSystemCanvas : Control
     protected override void OnGotFocus(GotFocusEventArgs e)
     {
         base.OnGotFocus(e);
+
+        // Ignore bubbled focus from child controls (inline editors), otherwise
+        // the canvas can immediately steal focus back from the textbox.
+        if (!ReferenceEquals(e.Source, this))
+            return;
+
         EnsureCanvasFocusAndSelection();
     }
 
     private void EnsureCanvasFocusAndSelection()
     {
         if (_vm is null) return;
-
-        if (!IsFocused)
-            Focus();
 
         if (_vm.SelectedElement is not null || _vm.SelectedLink is not null)
             return;
@@ -689,6 +694,8 @@ public sealed partial class ModelSystemCanvas : Control
             _lastCanvasMousePos = null;
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
+                if (!IsKeyboardFocusWithin)
+                    Focus();
                 EnsureCanvasFocusAndSelection();
                 InvalidateAndMeasure();
             }, Avalonia.Threading.DispatcherPriority.Render);

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
@@ -566,6 +566,22 @@ partial class ModelSystemCanvas
             menu.Items.Add(new Separator());
         }
 
+        if (element is NodeViewModel fileNodeVm && IsFilePathTargetNode(fileNodeVm))
+        {
+            var fileMenu = new MenuItem { Header = "File" };
+
+            var openFileItem = new MenuItem { Header = "Open" };
+            openFileItem.Click += async (_, _) => await TryOpenOpenReadStreamFromFileParameterAsync(fileNodeVm);
+            fileMenu.Items.Add(openFileItem);
+
+            var setFileItem = new MenuItem { Header = "Set…" };
+            setFileItem.Click += async (_, _) => await TryUpdateOpenReadStreamFromFileParameterAsync(fileNodeVm);
+            fileMenu.Items.Add(setFileItem);
+
+            menu.Items.Add(fileMenu);
+            menu.Items.Add(new Separator());
+        }
+
         // ── Standard Delete ───────────────────────────────────────────────
         var deleteItem = new MenuItem { Header = "Delete" };
         deleteItem.Click += (_, _) =>

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ContextMenu.cs
@@ -574,9 +574,13 @@ partial class ModelSystemCanvas
             openFileItem.Click += async (_, _) => await TryOpenOpenReadStreamFromFileParameterAsync(fileNodeVm);
             fileMenu.Items.Add(openFileItem);
 
-            var setFileItem = new MenuItem { Header = "Set…" };
-            setFileItem.Click += async (_, _) => await TryUpdateOpenReadStreamFromFileParameterAsync(fileNodeVm);
+            var setFileItem = new MenuItem { Header = "Set File…" };
+            setFileItem.Click += async (_, _) => await TryUpdateOpenReadStreamFromFileParameterAsync(false, fileNodeVm);
             fileMenu.Items.Add(setFileItem);
+
+            var setDirectoryItem = new MenuItem { Header = "Set Directory…" };
+            setDirectoryItem.Click += async (_, _) => await TryUpdateOpenReadStreamFromFileParameterAsync(true, fileNodeVm);
+            fileMenu.Items.Add(setDirectoryItem);
 
             menu.Items.Add(fileMenu);
             menu.Items.Add(new Separator());

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.CopyPaste.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.CopyPaste.cs
@@ -64,11 +64,11 @@ partial class ModelSystemCanvas
 
         return new CanvasElementDto(
             CanvasElementKind.Node,
-            node.Name,
             node.Location.X,
             node.Location.Y,
             (float)NodeRenderWidth(nvm),
             (float)NodeRenderHeight(nvm),
+            Name:            node.Name,
             TypeName:        node.Type?.AssemblyQualifiedName,
             ParameterValue:  paramValue,
             IsScriptedParam: isScriptedParam,
@@ -119,9 +119,11 @@ partial class ModelSystemCanvas
                     case CommentBlockViewModel cb:
                         dto = new CanvasElementDto(
                             CanvasElementKind.CommentBlock,
-                            cb.Name,
                             (float)cb.X, (float)cb.Y,
-                            (float)cb.Width, (float)cb.Height);
+                            (float)cb.Width, (float)cb.Height,
+                            Name: null,
+                            CommentBody: cb.Name,
+                            CommentHeader: cb.Header);
                         break;
 
                     case FunctionTemplateViewModel ft:
@@ -133,9 +135,9 @@ partial class ModelSystemCanvas
                             .ToList();
                         dto = new CanvasElementDto(
                             CanvasElementKind.FunctionTemplate,
-                            ft.Name,
                             (float)ft.X, (float)ft.Y,
                             (float)ft.Width, (float)ft.Height,
+                            Name: ft.Name,
                             EmbeddedTemplateSnapshot: templateSnapshot,
                             FunctionParameters: fpDtos.Count > 0 ? fpDtos : null);
                         break;
@@ -144,9 +146,9 @@ partial class ModelSystemCanvas
                         _vm.TryExportFunctionTemplateSnapshot(fi.UnderlyingInstance.Template, out var instanceTemplateSnapshot);
                         dto = new CanvasElementDto(
                             CanvasElementKind.FunctionInstance,
-                            fi.Name,
                             (float)fi.X, (float)fi.Y,
                             (float)fi.Width, (float)fi.Height,
+                            Name: fi.Name,
                             TemplateName: fi.TemplateName,
                             EmbeddedTemplateSnapshot: instanceTemplateSnapshot);
                         break;
@@ -154,9 +156,9 @@ partial class ModelSystemCanvas
                     case GhostNodeViewModel ghost:
                         dto = new CanvasElementDto(
                             CanvasElementKind.GhostNode,
-                            ghost.Name,
                             (float)ghost.X, (float)ghost.Y,
                             (float)ghost.Width, (float)ghost.Height,
+                            Name: ghost.Name,
                             ReferencedNodeName: ghost.UnderlyingGhostNode.ReferencedNode.Name);
                         break;
 
@@ -175,11 +177,11 @@ partial class ModelSystemCanvas
                     var t = fivm.UnderlyingInstance.Template;
                     dtos.Add(new CanvasElementDto(
                         CanvasElementKind.FunctionTemplate,
-                        t.Name,
                         t.Location.X,
                         t.Location.Y,
                         t.Location.Width,
                         t.Location.Height,
+                        Name: t.Name,
                         EmbeddedTemplateSnapshot: dto.EmbeddedTemplateSnapshot,
                         IsTemplateCompanion: true));
                 }

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -77,6 +77,19 @@ partial class ModelSystemCanvas
             ClearMultiSelection();
             e.Handled = true;
         }
+        else if ((e.Key is Key.Return or Key.Enter) && (e.KeyModifiers & KeyModifiers.Control) != 0)
+        {
+            if (_vm.SelectedElement is FunctionTemplateViewModel ftvm)
+            {
+                _vm.NavigateIntoFunctionTemplate(ftvm);
+                e.Handled = true;
+            }
+            else if (_vm.SelectedElement is FunctionInstanceViewModel fivm)
+            {
+                _vm.OpenFunctionTemplateOfInstance(fivm);
+                e.Handled = true;
+            }
+        }
         else if (e.Key == Key.F2 && _vm?.SelectedElement is not null)
         {
             var sel = _vm.SelectedElement;

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -163,6 +163,24 @@ partial class ModelSystemCanvas
                 e.Handled = true;
             }
         }
+        else if ((e.Key is Key.O) && (e.KeyModifiers & KeyModifiers.Control) != 0)
+        {
+            if (_vm?.SelectedElement is NodeViewModel nvm
+                && (nvm.IsParameterNode || nvm.UnderlyingNode.Type == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile)))
+            {
+                _ = TryOpenOpenReadStreamFromFileParameterAsync();
+                e.Handled = true;
+            }
+        }
+        else if( e.Key == Key.F && (e.KeyModifiers & KeyModifiers.Control) != 0)
+        {
+            if (_vm?.SelectedElement is NodeViewModel nvm
+                && (nvm.IsParameterNode || nvm.UnderlyingNode.Type == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile)))
+            {
+                _ = TryUpdateOpenReadStreamFromFileParameterAsync();
+                e.Handled = true;
+            }
+        }
         else if (e.Key == Key.Up
             && _editingParamNode is null
             && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift)) == 0)

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -30,12 +30,26 @@ namespace XTMF2.GUI.Controls;
 
 partial class ModelSystemCanvas
 {
+
+    private bool AltCommendIssued = false;
+
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        if (AltCommendIssued && (e.Key == Key.LeftAlt || e.Key == Key.RightAlt))
+        {
+            AltCommendIssued = false;
+            Focus();
+            e.Handled = true;
+        }
+        base.OnKeyUp(e);
+    }
+
     // ── Hit testing / mouse interaction ──────────────────────────────────
     protected override void OnKeyDown(KeyEventArgs e)
     {
-        base.OnKeyDown(e);
         if (_vm is null)
         {
+            base.OnKeyDown(e);
             return;
         }
         else if (e.Key is Key.Delete or Key.Back)
@@ -82,7 +96,12 @@ partial class ModelSystemCanvas
         else if (e.Key == Key.Up && (e.KeyModifiers & KeyModifiers.Alt) != 0)
         {
             // Alt+Up: navigate to parent boundary / exit function template.
+            AltCommendIssued = true;
             _vm?.NavigateUpCommand.Execute(null);
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                Focus();
+            }, Avalonia.Threading.DispatcherPriority.Render);
             e.Handled = true;
         }
         else if (e.Key == Key.C && (e.KeyModifiers & KeyModifiers.Control) != 0)
@@ -168,7 +187,9 @@ partial class ModelSystemCanvas
                 e.Handled = true;
             }
         }
+        base.OnKeyDown(e);
     }
+    
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         if ((e.KeyModifiers & KeyModifiers.Control) != 0)

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -180,10 +180,26 @@ partial class ModelSystemCanvas
         }
         else if (e.Key == Key.Tab && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Alt)) == 0)
         {
-            // Tab or Shift+Tab: navigate between parameters within a node or function instance.
+            // For comment blocks, Tab toggles header/body editing.
+            bool commentTabContext = _editingCommentBlock is not null
+                                  || _editingCommentHeaderBlock is not null
+                                  || _vm?.SelectedElement is CommentBlockViewModel;
+            if (commentTabContext && TryCycleCommentEditOnTab())
+            {
+                e.Handled = true;
+                return;
+            }
+
+            // Otherwise, Tab or Shift+Tab: navigate between parameters within a node or function instance.
             bool isShiftTab = (e.KeyModifiers & KeyModifiers.Shift) != 0;
             if (NavigateToNextParameter(isShiftTab))
             {
+                e.Handled = true;
+            }
+            else if (_vm?.SelectedElement is not null)
+            {
+                // Keep focus on the canvas when an element is selected even if
+                // there is no editable target for this Tab key press.
                 e.Handled = true;
             }
         }

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.Input.cs
@@ -177,7 +177,7 @@ partial class ModelSystemCanvas
             if (_vm?.SelectedElement is NodeViewModel nvm
                 && (nvm.IsParameterNode || nvm.UnderlyingNode.Type == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile)))
             {
-                _ = TryUpdateOpenReadStreamFromFileParameterAsync();
+                _ = TryUpdateOpenReadStreamFromFileParameterAsync(false);
                 e.Handled = true;
             }
         }

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.NameCommentEditing.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.NameCommentEditing.cs
@@ -180,6 +180,47 @@ partial class ModelSystemCanvas
         }
     }
 
+    /// <summary>
+    /// Handles Tab/Shift+Tab behavior for comment blocks.
+    /// If not currently editing, starts with header edit.
+    /// If already editing header/body, toggles to the other field.
+    /// </summary>
+    private bool TryCycleCommentEditOnTab()
+    {
+        // Never hijack Tab while other inline editors are active.
+        if (_editingParamNode is not null || _editingNameElement is not null)
+            return false;
+
+        var selectedComment = _vm?.SelectedElement as CommentBlockViewModel;
+
+        // If not currently editing a comment, only start the cycle when a comment is selected.
+        if (_editingCommentHeaderBlock is null && _editingCommentBlock is null && selectedComment is null)
+            return false;
+
+        var activeComment = _editingCommentHeaderBlock
+            ?? _editingCommentBlock
+            ?? selectedComment;
+
+        if (activeComment is null)
+            return false;
+
+        if (_editingCommentHeaderBlock is not null)
+        {
+            BeginCommentEdit(activeComment);
+            return true;
+        }
+
+        if (_editingCommentBlock is not null)
+        {
+            BeginCommentHeaderEdit(activeComment);
+            return true;
+        }
+
+        // Selected but not currently editing: start with header first.
+        BeginCommentHeaderEdit(activeComment);
+        return true;
+    }
+
     /// <summary>Shows the multi-line comment editor over <paramref name="comment"/>, positioned below the header band.</summary>
     private void BeginCommentEdit(CommentBlockViewModel comment)
     {
@@ -229,6 +270,14 @@ partial class ModelSystemCanvas
 
     private void OnCommentEditorKeyDown(object? sender, KeyEventArgs e)
     {
+        if (e.Key == Key.Tab && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Alt)) == 0)
+        {
+            if (TryCycleCommentEditOnTab())
+            {
+                e.Handled = true;
+                return;
+            }
+        }
         if ((e.Key is Key.Return or Key.Enter) && (e.KeyModifiers & KeyModifiers.Control) != 0)
         {
             // Ctrl+Enter commits; plain Enter inserts a newline (default).
@@ -304,6 +353,14 @@ partial class ModelSystemCanvas
 
     private void OnCommentHeaderEditorKeyDown(object? sender, KeyEventArgs e)
     {
+        if (e.Key == Key.Tab && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Alt)) == 0)
+        {
+            if (TryCycleCommentEditOnTab())
+            {
+                e.Handled = true;
+                return;
+            }
+        }
         if (e.Key is Key.Return or Key.Enter)
         {
             CommitCommentHeaderEdit();

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
@@ -288,15 +288,31 @@ partial class ModelSystemCanvas
         return null;
     }
 
-    private async Task TryOpenOpenReadStreamFromFileParameterAsync()
+    private static bool IsFilePathTargetNode(NodeViewModel? node)
     {
-        if (_vm?.SelectedElement is not NodeViewModel nvm)
+        return node is not null && (node.ModuleType switch
         {
-            _vm?.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
+            Type t when t == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile) => true,
+            Type t when t == typeof(XTMF2.RuntimeModules.BasicParameter<string>) => true,
+            Type t when t == typeof(XTMF2.RuntimeModules.ScriptedParameter<string>) => true,
+            _ => false
+        });
+    }
+
+    private async Task TryOpenOpenReadStreamFromFileParameterAsync(NodeViewModel? targetNodeModel = null)
+    {
+        var nvm = targetNodeModel ?? _vm?.SelectedElement as NodeViewModel;
+        if (_vm is null)
+        {
+            return;
+        }
+        if (nvm is null)
+        {
+            _vm.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
             return;
         }
 
-        if (!nvm.IsParameterNode && nvm.UnderlyingNode.Type?.FullName != "XTMF2.RuntimeModules.OpenReadStreamFromFile")
+        if (!IsFilePathTargetNode(nvm))
         {
             _vm.ShowToast("Select a file-path parameter node or an OpenReadStreamFromFile node.", isError: true, durationMs: 3000);
             return;
@@ -362,7 +378,7 @@ partial class ModelSystemCanvas
 
         if (string.IsNullOrWhiteSpace(currentValue))
         {
-            _vm.ShowToast("No file path is currently set.", isError: true, durationMs: 3000);
+            _vm?.ShowToast("No file path is currently set.", isError: true, durationMs: 3000);
             return;
         }
         // We need to check to see if it was a directory or if it was a file
@@ -385,15 +401,20 @@ partial class ModelSystemCanvas
         }
     }
 
-    private async Task TryUpdateOpenReadStreamFromFileParameterAsync()
+    private async Task TryUpdateOpenReadStreamFromFileParameterAsync(NodeViewModel? targetNode = null)
     {
-        if (_vm?.SelectedElement is not NodeViewModel nvm)
+        targetNode ??= _vm?.SelectedElement as NodeViewModel;
+        if (_vm is null)
         {
-            _vm?.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
+            return;
+        }
+        if (targetNode is not NodeViewModel nvm)
+        {
+            _vm.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
             return;
         }
 
-        if (!nvm.IsParameterNode && nvm.UnderlyingNode.Type?.FullName != "XTMF2.RuntimeModules.OpenReadStreamFromFile")
+        if (!IsFilePathTargetNode(nvm))
         {
             _vm.ShowToast("Select a file-path parameter node or an OpenReadStreamFromFile node.", isError: true, durationMs: 3000);
             return;

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
@@ -18,11 +18,16 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using XTMF2.GUI.ViewModels;
@@ -256,6 +261,179 @@ partial class ModelSystemCanvas
         _scriptOverlay.IsVisible = false;
         InvalidateAndMeasure();
         Focus();
+    }
+
+    private XTMF2.ModelSystemConstruct.Node? ResolveFilePathTargetNode(NodeViewModel node)
+    {
+        var sourceNode = node.UnderlyingNode;
+        if (sourceNode.ContainedWithin is null)
+            return null;
+
+        foreach (var link in sourceNode.ContainedWithin.Links)
+        {
+            if (!ReferenceEquals(link.Origin, sourceNode))
+                continue;
+            if (link.OriginHook?.Name != "File Path")
+                continue;
+
+            if (link is XTMF2.ModelSystemConstruct.SingleLink singleLink
+                && singleLink.Destination is XTMF2.ModelSystemConstruct.Node destinationNode)
+                return destinationNode;
+
+            if (link is XTMF2.ModelSystemConstruct.MultiLink multiLink
+                && multiLink.Destinations.FirstOrDefault() is XTMF2.ModelSystemConstruct.Node multiDestination)
+                return multiDestination;
+        }
+
+        return null;
+    }
+
+    private async Task TryOpenOpenReadStreamFromFileParameterAsync()
+    {
+        if (_vm?.SelectedElement is not NodeViewModel nvm)
+        {
+            _vm?.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
+            return;
+        }
+
+        if (!nvm.IsParameterNode && nvm.UnderlyingNode.Type?.FullName != "XTMF2.RuntimeModules.OpenReadStreamFromFile")
+        {
+            _vm.ShowToast("Select a file-path parameter node or an OpenReadStreamFromFile node.", isError: true, durationMs: 3000);
+            return;
+        }
+
+        string GetExpression(NodeViewModel node)
+        {
+            if (node.IsScriptedParameter)
+            {
+                return node.ParameterValueRepresentation ?? string.Empty;
+            }
+            else if(node.ModuleType == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile))
+            {
+                // For OpenReadStreamFromFile nodes, the file path is stored in the "FilePath" parameter.
+                var filePathParam = node.GetParameter("File Path");
+                if (filePathParam is null)
+                {
+                    return string.Empty;
+                }
+                if (filePathParam.ParameterValue?.GetValueAtEditingTime(typeof(string), out var value, out string? conversionError) ?? false)
+                {
+                    return value as string ?? string.Empty;
+                }
+                return string.Empty;
+            }
+            else
+            {
+                return node.ParameterValueRepresentation ?? string.Empty;
+            }
+        }
+
+        string GetResolvedValue(NodeViewModel node)
+        {
+            if (node.IsScriptedParameter)
+            {
+                return node.EvaluateParameterValue() ?? string.Empty;
+            }
+            else if(node.ModuleType == typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile))
+            {
+                var filePathParam = node.GetParameter("File Path");
+                if (filePathParam is null)
+                {
+                    return string.Empty;
+                }
+                if (filePathParam.ParameterValue?.GetValueAtEditingTime(typeof(string), out var value, out string? conversionError) ?? false)
+                {
+                    return value as string ?? string.Empty;
+                }
+                return string.Empty;
+            }
+            else
+            {
+                return node.ParameterValueRepresentation ?? string.Empty;
+            }
+        }
+
+        var targetNode = ResolveFilePathTargetNode(nvm) ?? nvm.UnderlyingNode;
+        var targetVm = ReferenceEquals(targetNode, nvm.UnderlyingNode)
+            ? nvm
+            : new NodeViewModel(targetNode, _vm.Session, _vm.User);
+        var currentExpression = GetExpression(targetVm);
+        var currentValue = GetResolvedValue(targetVm);
+
+        if (string.IsNullOrWhiteSpace(currentValue))
+        {
+            _vm.ShowToast("No file path is currently set.", isError: true, durationMs: 3000);
+            return;
+        }
+        // We need to check to see if it was a directory or if it was a file
+        var directoryInfo = new DirectoryInfo(currentValue);
+        var fileInfo = new FileInfo(currentValue);
+        ;
+        if (!directoryInfo.Exists && !fileInfo.Exists)
+        {
+            _vm.ShowToast($"The file '{currentValue}' does not exist.", isError: true, durationMs: 4000);
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = currentValue, UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _vm.ShowToast($"Unable to open '{currentValue}': {ex.Message}", isError: true, durationMs: 4000);
+        }
+    }
+
+    private async Task TryUpdateOpenReadStreamFromFileParameterAsync()
+    {
+        if (_vm?.SelectedElement is not NodeViewModel nvm)
+        {
+            _vm?.ShowToast("Select a file-path parameter node to update.", isError: true, durationMs: 3000);
+            return;
+        }
+
+        if (!nvm.IsParameterNode && nvm.UnderlyingNode.Type?.FullName != "XTMF2.RuntimeModules.OpenReadStreamFromFile")
+        {
+            _vm.ShowToast("Select a file-path parameter node or an OpenReadStreamFromFile node.", isError: true, durationMs: 3000);
+            return;
+        }
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel?.StorageProvider is null)
+        {
+            _vm.ShowToast("Unable to access the file system.", isError: true, durationMs: 3000);
+            return;
+        }
+
+        try
+        {
+            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+            {
+                Title = "Select File",
+                AllowMultiple = false,
+                FileTypeFilter = new[]
+                {
+                    new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+                }
+            });
+
+            if (files.Count == 0) return;
+
+            var filePath = files[0].TryGetLocalPath();
+            if (string.IsNullOrEmpty(filePath)) return;
+
+            if(!_vm.UpdateCurrentParameterValueFromFilePath(nvm, filePath, out var error))
+            {
+                _vm.ShowToast(error?.Message ?? "Failed to update the file path.", isError: true, durationMs: 4000);
+            }
+            
+            InvalidateVisual();
+        }
+        catch (Exception ex)
+        {
+            _vm.ShowToast($"Error opening file picker: {ex.Message}", isError: true, durationMs: 4000);
+        }
     }
 
     // ── Inline enum editor handlers ───────────────────────────────────────

--- a/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
+++ b/src/XTMF2.GUI/Controls/ModelSystemCanvas/ModelSystemCanvas.ParamEditing.cs
@@ -401,7 +401,7 @@ partial class ModelSystemCanvas
         }
     }
 
-    private async Task TryUpdateOpenReadStreamFromFileParameterAsync(NodeViewModel? targetNode = null)
+    private async Task TryUpdateOpenReadStreamFromFileParameterAsync(bool directory, NodeViewModel? targetNode = null)
     {
         targetNode ??= _vm?.SelectedElement as NodeViewModel;
         if (_vm is null)
@@ -429,24 +429,45 @@ partial class ModelSystemCanvas
 
         try
         {
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+            if(directory)
             {
-                Title = "Select File",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
+                var directories = await topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
                 {
-                    new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+                    Title = "Select Folder",
+                    AllowMultiple = false
+                });
+
+                if (directories.Count == 0) return;
+
+                var directoryPath = directories[0].TryGetLocalPath();
+                if (string.IsNullOrEmpty(directoryPath)) return;
+
+                if(!_vm.UpdateCurrentParameterValueFromFilePath(nvm, directoryPath, true, out var error))
+                {
+                    _vm.ShowToast(error?.Message ?? "Failed to update the directory path.", isError: true, durationMs: 4000);
                 }
-            });
-
-            if (files.Count == 0) return;
-
-            var filePath = files[0].TryGetLocalPath();
-            if (string.IsNullOrEmpty(filePath)) return;
-
-            if(!_vm.UpdateCurrentParameterValueFromFilePath(nvm, filePath, out var error))
+            }
+            else
             {
-                _vm.ShowToast(error?.Message ?? "Failed to update the file path.", isError: true, durationMs: 4000);
+                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+                {
+                    Title = "Select File",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
+                    {
+                        new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+                    }
+                });
+
+                if (files.Count == 0) return;
+
+                var filePath = files[0].TryGetLocalPath();
+                if (string.IsNullOrEmpty(filePath)) return;
+
+                if(!_vm.UpdateCurrentParameterValueFromFilePath(nvm, filePath, false, out var error))
+                {
+                    _vm.ShowToast(error?.Message ?? "Failed to update the file path.", isError: true, durationMs: 4000);
+                }
             }
             
             InvalidateVisual();

--- a/src/XTMF2.GUI/ViewModels/CanvasClipboardPayload.cs
+++ b/src/XTMF2.GUI/ViewModels/CanvasClipboardPayload.cs
@@ -54,7 +54,12 @@ internal sealed record CanvasClipboardPayload(
 /// All element types share this record; unused fields are omitted from JSON.
 /// </summary>
 /// <param name="Kind">Discriminator — one of the <see cref="CanvasElementKind"/> constants.</param>
-/// <param name="Name">Display name of the element.</param>
+/// <param name="Name">
+/// Display name of the element. For <see cref="CanvasElementKind.CommentBlock"/>,
+/// this is treated as a legacy fallback for older payloads.
+/// </param>
+/// <param name="CommentBody">Body text for <see cref="CanvasElementKind.CommentBlock"/>.</param>
+/// <param name="CommentHeader">Header text for <see cref="CanvasElementKind.CommentBlock"/>.</param>
 /// <param name="X">Canvas X coordinate.</param>
 /// <param name="Y">Canvas Y coordinate.</param>
 /// <param name="W">Canvas width.</param>
@@ -101,11 +106,11 @@ internal sealed record CanvasClipboardPayload(
 /// </param>
 internal sealed record CanvasElementDto(
     [property: JsonPropertyName("kind")]               string  Kind,
-    [property: JsonPropertyName("name")]               string  Name,
     [property: JsonPropertyName("x")]                  float   X,
     [property: JsonPropertyName("y")]                  float   Y,
     [property: JsonPropertyName("w")]                  float   W,
     [property: JsonPropertyName("h")]                  float   H,
+    [property: JsonPropertyName("name")]               string?             Name                = null,
     [property: JsonPropertyName("typeName")]           string?              TypeName            = null,
     [property: JsonPropertyName("paramValue")]         string?              ParameterValue      = null,
     [property: JsonPropertyName("isScriptedParam")]    bool                 IsScriptedParam     = false,
@@ -115,7 +120,9 @@ internal sealed record CanvasElementDto(
     [property: JsonPropertyName("referencedNodeName")] string?             ReferencedNodeName  = null,
     [property: JsonPropertyName("functionParameters")] List<FunctionParameterDto>? FunctionParameters = null,
     [property: JsonPropertyName("crossLinks")]         List<CrossNodeLinkDto>? CrossLinks        = null,
-    [property: JsonPropertyName("isTemplateCompanion")] bool               IsTemplateCompanion = false
+    [property: JsonPropertyName("isTemplateCompanion")] bool               IsTemplateCompanion = false,
+    [property: JsonPropertyName("body")]               string?             CommentBody         = null,
+    [property: JsonPropertyName("commentHeader")]      string?             CommentHeader       = null
 );
 
 /// <summary>

--- a/src/XTMF2.GUI/ViewModels/CommentBlockViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/CommentBlockViewModel.cs
@@ -181,11 +181,10 @@ public sealed partial class CommentBlockViewModel : ObservableObject, ICanvasEle
 
     /// <summary>
     /// Update the comment text, persisting the change via the session (supports undo/redo).
-    /// Whitespace-only text is ignored.
+    /// Empty text is valid.
     /// </summary>
     public void SetText(string text)
     {
-        if (string.IsNullOrWhiteSpace(text)) return;
         _session.SetCommentBlockText(_user, UnderlyingBlock, text, out _);
     }
 

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -815,7 +815,9 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
             foreach (var fp in _currentFunctionTemplate.UnderlyingTemplate.FunctionParameters)
                 FunctionParameterVMs.Add(new FunctionParameterViewModel(fp, Session, User));
         foreach (var link in boundary.Links)          TryAddLinkViewModel(link);
-        foreach (var cb in boundary.CommentBlocks)    CommentBlocks.Add(new CommentBlockViewModel(cb, Session, User));
+        foreach (var cb in boundary.CommentBlocks)
+            if (!CommentBlocks.Any(v => ReferenceEquals(v.UnderlyingBlock, cb)))
+                CommentBlocks.Add(new CommentBlockViewModel(cb, Session, User));
     }
 
     // Cached reference to the current boundary's Boundaries collection so we can
@@ -1011,6 +1013,13 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         if (e.NewItems is not null)
             foreach (CommentBlock cb in e.NewItems)
             {
+                var existing = CommentBlocks.FirstOrDefault(v => ReferenceEquals(v.UnderlyingBlock, cb));
+                if (existing is not null)
+                {
+                    SelectElement(existing);
+                    continue;
+                }
+
                 var cvm = new CommentBlockViewModel(cb, Session, User);
                 CommentBlocks.Add(cvm);
                 SelectElement(cvm);
@@ -4070,7 +4079,9 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
             // Pass 3: restore links between pasted nodes (cross-node links).
             if (createdNodes.Count > 1)
             {
-                var nameToNode = createdNodes.ToDictionary(e => e.Element.Name, e => e.Node);
+                var nameToNode = createdNodes
+                    .Where(e => !string.IsNullOrWhiteSpace(e.Element.Name))
+                    .ToDictionary(e => e.Element.Name!, e => e.Node);
                 foreach (var (element, originNode) in createdNodes)
                 {
                     foreach (var crossLink in element.CrossLinks ?? [])
@@ -4126,8 +4137,9 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         float w = element.W > 0 ? element.W : 120f;
         float h = element.H > 0 ? element.H : 50f;
         var newLoc = new Rectangle(element.X + dx, element.Y + dy, w, h);
+        var nodeName = string.IsNullOrWhiteSpace(element.Name) ? "Pasted Node" : element.Name;
 
-        if (!Session.AddNode(User, _currentBoundary, element.Name, type, newLoc,
+        if (!Session.AddNode(User, _currentBoundary, nodeName, type, newLoc,
                 out var newNode, out var addError))
         {
             await ShowError("Paste Failed", addError);
@@ -4162,8 +4174,9 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
 
             var hook = newNode.Hooks?.FirstOrDefault(h => h.Name == inlined.HookName);
             if (hook is null) continue;
+            var childName = string.IsNullOrWhiteSpace(inlined.Child.Name) ? "Pasted Node" : inlined.Child.Name;
 
-            if (!Session.AddNode(User, _currentBoundary, inlined.Child.Name, childType,
+            if (!Session.AddNode(User, _currentBoundary, childName, childType,
                     Rectangle.Hidden, out var childNode, out _))
                 continue;
 
@@ -4185,8 +4198,15 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         float w = element.W > 0 ? element.W : (float)CommentBlockViewModel.DefaultWidth;
         float h = element.H > 0 ? element.H : (float)CommentBlockViewModel.DefaultHeight;
         var loc = new Rectangle(element.X + dx, element.Y + dy, w, h);
-        // Name on CommentBlock stores the comment text.
-        Session.AddCommentBlock(User, _currentBoundary, element.Name, loc, out _, out _);
+        // Prefer the dedicated comment body field; fall back to legacy payloads using "name".
+        var body = element.CommentBody ?? element.Name ?? string.Empty;
+        if (!Session.AddCommentBlock(User, _currentBoundary, body, loc, out var block, out _)
+            || block is null)
+        {
+            return;
+        }
+
+        Session.SetCommentBlockHeader(User, block, element.CommentHeader ?? string.Empty, out _);
     }
 
     private FunctionTemplate? PasteFunctionTemplate(CanvasElementDto element, float dx, float dy)
@@ -4221,10 +4241,11 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         }
 
         // Legacy fallback for payloads without embedded template snapshots.
-        string name = element.Name;
+        string baseName = string.IsNullOrWhiteSpace(element.Name) ? "Function Template" : element.Name;
+        string name = baseName;
         int suffix = 2;
         while (FunctionTemplates.Any(ft => string.Equals(ft.Name, name, StringComparison.OrdinalIgnoreCase)))
-            name = $"{element.Name} ({suffix++})";
+            name = $"{baseName} ({suffix++})";
 
         if (!Session.AddFunctionTemplate(User, _currentBoundary, name, out var ft, out _))
             return null;
@@ -4253,10 +4274,11 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         if (template is null) return;
 
         // Generate a unique name if needed.
-        string name = element.Name;
+        string baseName = string.IsNullOrWhiteSpace(element.Name) ? "Function Instance" : element.Name;
+        string name = baseName;
         int suffix = 2;
         while (_currentBoundary.FunctionInstances.Any(fi => string.Equals(fi.Name, name, StringComparison.OrdinalIgnoreCase)))
-            name = $"{element.Name} ({suffix++})";
+            name = $"{baseName} ({suffix++})";
 
         float w = element.W > 0 ? element.W : 160f;
         float h = element.H > 0 ? element.H : 70f;

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -38,6 +38,7 @@ using XTMF2.GUI.Resources;
 using XTMF2.GUI.Views;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.RuntimeModules;
+using System.Diagnostics.CodeAnalysis;
 
 namespace XTMF2.GUI.ViewModels;
 
@@ -4354,6 +4355,12 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         Session.AddGhostNode(User, _currentBoundary, referencedNvm.UnderlyingNode, loc, out _, out _);
     }
 
+    internal bool UpdateCurrentParameterValueFromFilePath(NodeViewModel nvm, string newFilePath, 
+        [NotNullWhen(false) ]out CommandError? error)
+    {
+        return Session.SetParameterValueFromFilePath(User, nvm.UnderlyingNode, newFilePath, out error);
+    }
+
     // ── IDisposable ───────────────────────────────────────────────────────
     /// <inheritdoc />
     public void Dispose()
@@ -4384,4 +4391,5 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
 
         Session.Dispose();
     }
+
 }

--- a/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/ModelSystemEditorViewModel.cs
@@ -4355,10 +4355,10 @@ public sealed partial class ModelSystemEditorViewModel : ObservableObject, IDisp
         Session.AddGhostNode(User, _currentBoundary, referencedNvm.UnderlyingNode, loc, out _, out _);
     }
 
-    internal bool UpdateCurrentParameterValueFromFilePath(NodeViewModel nvm, string newFilePath, 
+    internal bool UpdateCurrentParameterValueFromFilePath(NodeViewModel nvm, string newFilePath, bool isDirectory,
         [NotNullWhen(false) ]out CommandError? error)
     {
-        return Session.SetParameterValueFromFilePath(User, nvm.UnderlyingNode, newFilePath, out error);
+        return Session.SetParameterValueFromFilePath(User, nvm.UnderlyingNode, newFilePath, isDirectory, out error);
     }
 
     // ── IDisposable ───────────────────────────────────────────────────────

--- a/src/XTMF2.GUI/ViewModels/NodeViewModel.cs
+++ b/src/XTMF2.GUI/ViewModels/NodeViewModel.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.ComponentModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using XTMF2;
 using XTMF2.Configuration;
@@ -78,6 +79,11 @@ public sealed partial class NodeViewModel : ObservableObject, ICanvasElement
     /// (e.g. "BasicParameter`1"). Updates automatically when the type changes.
     /// </summary>
     public string TypeName => UnderlyingNode.Type?.Name ?? "Unknown";
+
+    /// <summary>
+    /// Get the underlying module's type.
+    /// </summary>
+    public Type ModuleType => UnderlyingNode.Type;
 
     /// <summary>
     /// True when the node's type is <see cref="BasicParameter{T}"/> or
@@ -419,5 +425,28 @@ public sealed partial class NodeViewModel : ObservableObject, ICanvasElement
         var h = loc.Height > 0 ? loc.Height : 50f;
         _session.SetNodeLocation(_user, UnderlyingNode,
             new Rectangle((float)x, (float)y, w, h), out _);
+    }
+
+    internal Node? GetParameter(string parameterName)
+    {
+        var parameter = UnderlyingNode.GetParameter(_session, parameterName);
+        return parameter;
+    }
+
+    internal string? EvaluateParameterValue()
+    {
+        if (IsScriptedParameter)
+        {
+            if (!_session.EvaluateParameterExpression(UnderlyingNode, out object? value)
+                || value is not String)
+            {
+                return String.Empty;
+            }
+            return value as String;
+        }
+        else
+        {
+            return UnderlyingNode.ParameterValue?.Representation ?? string.Empty;
+        }
     }
 }

--- a/src/XTMF2.GUI/Views/ModelSystemEditorView.axaml
+++ b/src/XTMF2.GUI/Views/ModelSystemEditorView.axaml
@@ -66,7 +66,6 @@
         <KeyBinding Gesture="Ctrl+Z" Command="{Binding UndoCommand}"/>
         <KeyBinding Gesture="Ctrl+Y" Command="{Binding RedoCommand}"/>
         <KeyBinding Gesture="Ctrl+B" Command="{Binding BrowseBoundariesCommand}"/>
-        <KeyBinding Gesture="Alt+Up" Command="{Binding NavigateUpCommand}"/>
     </UserControl.KeyBindings>
 
     <Grid RowDefinitions="Auto,*" Margin="10">

--- a/src/XTMF2/Bus/Run.cs
+++ b/src/XTMF2/Bus/Run.cs
@@ -241,10 +241,10 @@ namespace XTMF2.Bus
             try
             {
                 Directory.SetCurrentDirectory(_currentWorkingDirectory);
-                if (!RuntimeValidation(ref moduleName, ref error))
+                if (!RuntimeValidation(ref moduleName, ref error, ref elementId))
                 {
-                    RunResults.WriteValidationError(_currentWorkingDirectory, moduleName, error);
-                    return new RunError(RunErrorType.Runtime, error, moduleName, stackTrace);
+                    RunResults.WriteValidationError(_currentWorkingDirectory, moduleName, error, elementId);
+                    return new RunError(RunErrorType.Runtime, error, moduleName, stackTrace, elementId);
                 }
                 if(startingMss.Module is IAction modelStart)
                 {
@@ -368,7 +368,7 @@ namespace XTMF2.Bus
             return false;
         }
 
-        private bool RuntimeValidation(ref string? moduleName, ref string? errorMessage)
+        private bool RuntimeValidation(ref string? moduleName, ref string? errorMessage, ref Guid? elementId)
         {
             Stack<Boundary> toProcess = new Stack<Boundary>();
             toProcess.Push(_modelSystem!.GlobalBoundary);
@@ -387,6 +387,7 @@ namespace XTMF2.Bus
                             if (!realModule.RuntimeValidation(ref errorMessage))
                             {
                                 moduleName = module.Name;
+                                elementId = module.Id;
                                 return false;
                             }
                         }
@@ -394,6 +395,7 @@ namespace XTMF2.Bus
                         {
                             moduleName = module.Name;
                             errorMessage = e.Message;
+                            elementId = module.Id;
                             return false;
                         }
                     }
@@ -401,7 +403,10 @@ namespace XTMF2.Bus
                 foreach (var fi in current.FunctionInstances)
                 {
                     if (!fi.ValidateRuntimeModules(ref moduleName, ref errorMessage))
+                    {
+                        elementId = fi.Id;
                         return false;
+                    }
                 }
             }
             return true;

--- a/src/XTMF2/Editing/ModelSystemSession.cs
+++ b/src/XTMF2/Editing/ModelSystemSession.cs
@@ -2367,17 +2367,28 @@ namespace XTMF2.Editing
         /// <param name="user">The user issuing the command</param>
         /// <param name="nodeToAssign">The parameter to set.</param>
         /// <param name="filePath">The file path to set the parameter to.</param
+        /// <param name="isDirectory">Whether the file path is a directory or not.</param>
         /// <param name="error">An error message if the operation fails.</param>
         /// <returns>True if the operation succeeds, false otherwise with an error message.</returns
-        public bool SetParameterValueFromFilePath(User user, Node nodeToAssign, string filePath, [NotNullWhen(false)] out CommandError? error)
+        public bool SetParameterValueFromFilePath(User user, Node nodeToAssign, string filePath, bool isDirectory, [NotNullWhen(false)] out CommandError? error)
         {
             ArgumentNullException.ThrowIfNull(user);
             ArgumentNullException.ThrowIfNull(nodeToAssign);
-            
-            if (filePath is null || !File.Exists(filePath))
+            if(isDirectory)
             {
-                error = new CommandError($"The file path '{filePath}' does not exist.", false);
-                return false;
+                if (filePath is null || !Directory.Exists(filePath))
+                {
+                    error = new CommandError($"The directory path '{filePath}' does not exist.", false);
+                    return false;
+                }
+            }
+            else
+            {
+                if (filePath is null || !File.Exists(filePath))
+                {
+                    error = new CommandError($"The file path '{filePath}' does not exist.", false);
+                    return false;
+                }
             }
 
             lock (_sessionLock)

--- a/src/XTMF2/Editing/ModelSystemSession.cs
+++ b/src/XTMF2/Editing/ModelSystemSession.cs
@@ -1,5 +1,5 @@
 ﻿/*
-    Copyright 2017-2021 University of Toronto
+    Copyright 2017-2026 University of Toronto
     This file is part of XTMF2.
     XTMF2 is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ using System.Threading;
 using System.ComponentModel;
 using XTMF2.ModelSystemConstruct;
 using XTMF2.ModelSystemConstruct.Parameters;
+using XTMF2.ModelSystemConstruct.Parameters.Compiler;
 using XTMF2.Repository;
 using XTMF2.Bus.Optimization;
 
@@ -491,6 +492,19 @@ namespace XTMF2.Editing
                 or "Width"
                 or "Height"
                 or "Location";
+        }
+
+        private sealed class DesignTimeModule : IModule
+        {
+            public string? Name { get; set; }
+
+            public DesignTimeModule(string? name) => Name = name;
+
+            public bool RuntimeValidation(ref string? error)
+            {
+                error = null;
+                return true;
+            }
         }
 
         private void OnBufferPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -2251,6 +2265,51 @@ namespace XTMF2.Editing
         }
 
         /// <summary>
+        /// Evaluates a node's current parameter expression using the same expression engine
+        /// that the runtime uses, without mutating the model system.
+        /// </summary>
+        /// <param name="node">The parameter-bearing node whose expression should be evaluated.</param>
+        /// <param name="value">The evaluated value, or <c>null</c> when evaluation fails.</param>
+        /// <returns><c>true</c> when the expression evaluates successfully.</returns>
+        public bool EvaluateParameterExpression(Node node, out object? value)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+            value = null;
+
+            lock (_sessionLock)
+            {
+                if (node.ParameterValue is null)
+                    return false;
+
+                var designTimeModule = new DesignTimeModule(node.Name ?? "DesignTimeModule");
+                var expectedType = node.ParameterValue.Type;
+                if (node.ParameterValue is ScriptedParameter scripted)
+                {
+                    string? error = null;
+                    var localVars = node.ContainedWithin?.OwningFunctionTemplate?.LocalVariables;
+                    IList<Node> allVars = localVars is { Count: > 0 }
+                        ? localVars.Concat(ModelSystem.Variables).ToList()
+                        : (IList<Node>)ModelSystem.Variables;
+                    if (!ParameterCompiler.CreateExpression(allVars, scripted.Representation, out var expression, ref error))
+                        return false;
+
+                    if (!ParameterCompiler.Evaluate(designTimeModule, expression, out value, ref error))
+                        return false;
+
+                    return true;
+                }
+
+                string? parseError = null;
+                var result = node.ParameterValue.GetValue(designTimeModule, expectedType, ref parseError);
+                if (parseError is not null)
+                    return false;
+
+                value = result;
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Set the value of a parameter
         /// </summary>
         /// <param name="user">The user issuing the command</param>
@@ -2270,20 +2329,186 @@ namespace XTMF2.Editing
                     error = new CommandError("The user does not have access to this project.", true);
                     return false;
                 }
-                var previousValue = basicParameter.ParameterValue;
-                var newValue = ParameterExpression.CreateParameter(value, basicParameter.Type.GetGenericArguments()[0]);
-                if (basicParameter.SetParameterValue(newValue, out error))
+                return InnerSetBasicParameter(basicParameter, value, out error);
+            }
+        }
+
+        /// <summary>
+        /// Set the value of a parameter without checking user access (for internal use only)
+        /// <b>Must already own the session lock.</b>
+        /// </summary>
+        /// <param name="basicParameter">The parameter to set.</param>
+        /// <param name="value">The value to set the parameter to.</param>
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise with an error message.</returns
+        private bool InnerSetBasicParameter(Node basicParameter, string value, out CommandError? error)
+        {
+            var previousValue = basicParameter.ParameterValue;
+            var newValue = ParameterExpression.CreateParameter(value, basicParameter.Type.GetGenericArguments()[0]);
+            if (basicParameter.SetParameterValue(newValue, out error))
+            {
+                Buffer.AddUndo(new Command(() =>
                 {
-                    Buffer.AddUndo(new Command(() =>
+                    return (basicParameter.SetParameterValue(previousValue!, out var e), e);
+                }, () =>
+                {
+                    return (basicParameter.SetParameterValue(newValue, out var e), e);
+                }));
+                return true;
+            }
+            return false;
+        }
+
+
+
+        /// <summary>
+        /// Set the value of a parameter from a file path
+        /// </summary>
+        /// <param name="user">The user issuing the command</param>
+        /// <param name="nodeToAssign">The parameter to set.</param>
+        /// <param name="filePath">The file path to set the parameter to.</param
+        /// <param name="error">An error message if the operation fails.</param>
+        /// <returns>True if the operation succeeds, false otherwise with an error message.</returns
+        public bool SetParameterValueFromFilePath(User user, Node nodeToAssign, string filePath, [NotNullWhen(false)] out CommandError? error)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(nodeToAssign);
+            
+            if (filePath is null || !File.Exists(filePath))
+            {
+                error = new CommandError($"The file path '{filePath}' does not exist.", false);
+                return false;
+            }
+
+            lock (_sessionLock)
+            {
+                if (!_session.HasAccess(user))
+                {
+                    error = new CommandError("The user does not have access to this project.", true);
+                    return false;
+                }
+
+                // Check the type of the current node:
+                // InnerType == typeof(OpenReadStream), then we need to get the node referenced by the hook "File Path" and set the value of that node to the file path.
+                // BasicParameter, we can set the value from the file path
+                // ScriptedParaemeter, we need to explore its AST and see if we can update the right hand side addition and then only update that script's constant.
+                if (nodeToAssign.Type == typeof(RuntimeModules.OpenReadStreamFromFile))
+                {
+                    var links = nodeToAssign.ContainedWithin?.Links;
+                    var link = links?.FirstOrDefault(l => l.Origin == nodeToAssign && l.OriginHook?.Name == "File Path");
+                    // link is null if there is no BasicParameter or ScriptedParameter to save the value to.
+                    // TODO: resolve this by creating a new BasicParameter and linking it to the OpenReadStreamFromFile node.
+                    if (link is null)
                     {
-                        return (basicParameter.SetParameterValue(previousValue!, out var e), e);
-                    }, () =>
+                        error = new CommandError("There is no link for the OpenReadStreamFromFile to set the file path to.", false);
+                        return false;
+                    }
+
+                    if(!link.TryGetFirstDestination(out var destination))
                     {
-                        return (basicParameter.SetParameterValue(newValue, out var e), e);
-                    }));
+                        error = new CommandError("The link for the OpenReadStreamFromFile does not have a valid destination.", false);
+                        return false;
+                    }
+
+                    if (destination is Node destNode)
+                    {
+                        nodeToAssign = destNode;                        
+                    }
+                    else
+                    {
+                        error = new CommandError("Only Nodes are currently supported for storing the file path to.", false);
+                        return false;
+                    }
+                }
+                // At this point nodeToAssign should be a BasicParameter or ScriptedParameter that we can set the value of.
+                if ((nodeToAssign?.Type?.IsAssignableFrom(typeof(RuntimeModules.ScriptedParameter<string>)) ?? false) == true)
+                {
+                    var parameterValue = nodeToAssign.ParameterValue;
+
+                    List<Node> availableVariables = [];
+                    // Put the local variables first so they get resolved first.
+                    var localVariables = nodeToAssign.ContainedWithin?.OwningFunctionTemplate?.LocalVariables;
+                    if(localVariables is not null && localVariables.Count > 0)
+                    {
+                        availableVariables = [.. availableVariables, .. localVariables];
+                    }
+                    // append the higher order model system variables second so they get resolved last.
+                    availableVariables = [.. availableVariables, .. this.ModelSystem.Variables];
+                    string? e = null;
+                    if (!ParameterCompiler.CreateExpression(availableVariables, parameterValue?.Representation!, out var expression, ref e))
+                    {
+                        error = new CommandError($"Failed to parse the ScriptedParameter expression: {e}", false);
+                        return false;
+                    }
+                    // MAke sure it resolves to a string before we try to explore it.
+                    if (expression.Type != typeof(string))
+                    {
+                        error = new CommandError($"The ScriptedParameter expression did not evaluate to a string.", false);
+                        return false;
+                    }
+                    // Check if we have the pattern where the LHS are variables and the RHS is a string literal.
+                    if (expression is AddOperator add)
+                    {
+                        var lhs = add._lhs as StringVariable;
+                        var rhs = add._rhs as StringLiteral;
+                        // If we have this pattern then we can try to solve it
+                        if (lhs is not null && rhs is not null)
+                        {
+                            var lhsResult = lhs.GetResult(null!);
+                            if (lhsResult.ReturnType == typeof(string))
+                            {
+                                if (lhsResult.TryGetResult(out var lhsr2, ref e) && lhsr2 is string lhsPath)
+                                {
+                                    // Check if the lhsPath is a subset of the current path
+                                    if (filePath.StartsWith(lhsPath))
+                                    {
+                                        filePath = filePath[lhsPath.Length..];
+                                        StringBuilder sb = new ();
+                                        sb.Append(lhs.AsString());
+                                        sb.Append(" + \"");
+                                        sb.Append(filePath);
+                                        sb.Append("\"");
+                                        var optimizedExpression = ParameterExpression.CreateParameter(sb.ToString(), typeof(string));
+                                        if (nodeToAssign.SetParameterValue(optimizedExpression, out error))
+                                        {
+                                            Buffer.AddUndo(new Command(() =>
+                                            {
+                                                return (nodeToAssign.SetParameterValue(parameterValue!, out var e), e);
+                                            }, () =>
+                                            {
+                                                return (nodeToAssign.SetParameterValue(optimizedExpression, out var e), e);
+                                            }));
+                                            return true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // If we get here then we were not able to match a pattern that we can solve, so we will just assign the scriped parameter as a literal.
+                    var newExpression = ParameterExpression.CreateParameter($"\"{filePath}\"", typeof(string));
+                    if (nodeToAssign.SetParameterValue(newExpression, out error))
+                    {
+                        Buffer.AddUndo(new Command(() =>
+                        {
+                            return (nodeToAssign.SetParameterValue(parameterValue!, out var e), e);
+                        }, () =>
+                        {
+                            return (nodeToAssign.SetParameterValue(newExpression, out var e), e);
+                        }));
+                        return true;
+                    }
                     return true;
                 }
-                return false;
+                else if(nodeToAssign?.Type?.IsAssignableFrom(typeof(RuntimeModules.BasicParameter<string>)) ?? false)
+                {
+                    return InnerSetBasicParameter(nodeToAssign, filePath, out error);
+                }
+                else
+                {
+                    error = new CommandError($"The node type '{nodeToAssign?.Type}' is not supported for setting a file path.", false);
+                    return false;
+                }
             }
         }
 
@@ -5860,6 +6085,49 @@ namespace XTMF2.Editing
                     () => { entry.TargetOutputNode = targetOutputNode; return (true, null); }));
                 error = null;
                 return true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the parameter node for a given node and parameter name.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="parameterNode"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        internal bool GetParameterForNode(Node node, string parameterName,
+         [NotNullWhen(true)] out Node? parameterNode, [NotNullWhen(false)] out string? error)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+            ArgumentNullException.ThrowIfNull(parameterName);
+            lock (_sessionLock)
+            {
+                var containingBoundary = node.ContainedWithin ?? throw new InvalidOperationException("Node is not contained within a boundary.");
+                var link = containingBoundary.Links.FirstOrDefault(lk => lk.Origin == node && lk.OriginHook?.Name == parameterName);
+                if(link is null)
+                {
+                    parameterNode = null;
+                    error = $"No parameter named '{parameterName}' was found for node '{node.Name}'.";
+                    return false;
+                }
+                if(link.TryGetFirstDestination(out var dest))
+                {
+                    parameterNode = dest as Node;
+                    if (parameterNode is null)
+                    {
+                        error = $"The parameter '{parameterName}' either has no destination or one that is not a node.";
+                        return false;
+                    }
+                    error = null;
+                    return true;
+                }
+                else
+                {
+                    parameterNode = null;
+                    error = $"The parameter link for '{parameterName}' on node '{node.Name}' has no destination.";
+                    return false;
+                }
             }
         }
     }

--- a/src/XTMF2/Editing/ModelSystemSession.cs
+++ b/src/XTMF2/Editing/ModelSystemSession.cs
@@ -726,11 +726,7 @@ namespace XTMF2.Editing
             ArgumentNullException.ThrowIfNull(user);
             ArgumentNullException.ThrowIfNull(boundary);
 
-            if (String.IsNullOrWhiteSpace(comment))
-            {
-                error = new CommandError("There was no comment to store.");
-                return false;
-            }
+            comment ??= string.Empty;
             lock (_sessionLock)
             {
                 if (!_session.HasAccess(user))
@@ -847,11 +843,7 @@ namespace XTMF2.Editing
             ArgumentNullException.ThrowIfNull(user);
             ArgumentNullException.ThrowIfNull(commentBlock);
 
-            if (string.IsNullOrEmpty(newText))
-            {
-                error = new CommandError("A comment block must have text!");
-                return false;
-            }
+            newText ??= string.Empty;
             lock (_sessionLock)
             {
                 if (!_session.HasAccess(user))

--- a/src/XTMF2/ModelSystemConstruct/FunctionInstance.cs
+++ b/src/XTMF2/ModelSystemConstruct/FunctionInstance.cs
@@ -372,6 +372,15 @@ namespace XTMF2.ModelSystemConstruct
                 finally { _contextStack.Pop(); }
             }
 
+            public override bool GetValueAtEditingTime(Type outputType, 
+                [NotNullWhen(true)] out object? convertedValue,
+                [NotNullWhen(false)] out string? errorString)
+            {
+                (_contextStack ??= new Stack<FunctionInstance>()).Push(_fi);
+                try   { return _inner.GetValueAtEditingTime(outputType, out convertedValue, out errorString); }
+                finally { _contextStack.Pop(); }
+            }
+
             public override string Representation => _inner.Representation;
             public override Type Type => _inner.Type;
 

--- a/src/XTMF2/ModelSystemConstruct/Link.cs
+++ b/src/XTMF2/ModelSystemConstruct/Link.cs
@@ -303,5 +303,8 @@ namespace XTMF2
         internal abstract bool SetAllDestinationsHidden(bool hidden, [NotNullWhen(false)] out CommandError? error);
 
         internal abstract bool HasDestination(Node destNode);
+
+        internal abstract bool TryGetFirstDestination([NotNullWhen(true)] out object? dest);
+        
     }
 }

--- a/src/XTMF2/ModelSystemConstruct/MultiLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/MultiLink.cs
@@ -237,5 +237,16 @@ namespace XTMF2.ModelSystemConstruct
         {
             return _Destinations.Contains(destNode);
         }
+
+        override internal bool TryGetFirstDestination([NotNullWhen(true)] out object? dest)
+        {
+            if (_Destinations.Count > 0)
+            {
+                dest = _Destinations[0];
+                return true;
+            }
+            dest = null;
+            return false;
+        }
     }
 }

--- a/src/XTMF2/ModelSystemConstruct/Node.cs
+++ b/src/XTMF2/ModelSystemConstruct/Node.cs
@@ -599,5 +599,11 @@ namespace XTMF2.ModelSystemConstruct
             }
             return new Node(name, type, boundary, hooks, location);
         }
+
+        public Node? GetParameter(ModelSystemSession session, string parameterName)
+        {
+            session.GetParameterForNode(this, parameterName, out var parameterNode, out var error);
+            return parameterNode;
+        }
     }
 }

--- a/src/XTMF2/ModelSystemConstruct/ParameterExpression.cs
+++ b/src/XTMF2/ModelSystemConstruct/ParameterExpression.cs
@@ -45,6 +45,17 @@ public abstract class ParameterExpression : INotifyPropertyChanged
     public abstract object? GetValue(IModule caller, Type type, ref string? errorString);
 
     /// <summary>
+    /// Tries to convert the parameter expression to the given type at editing time.
+    /// This is used for modules that need to evaluate the parameter expression at editing time.
+    /// </summary>
+    /// <param name="outputType">The expected output type.</param>
+    /// <param name="errorString">An error message if we are unable to get the value.</param>
+    /// <returns>True if the value was successfully obtained, false otherwise.</returns>
+    public abstract bool GetValueAtEditingTime(Type outputType, 
+        [NotNullWhen(true)] out object? convertedValue,
+        [NotNullWhen(false)] out string? errorString);
+
+    /// <summary>
     /// Gets a string based representation of the parameter
     /// </summary>
     public abstract string Representation { get; }

--- a/src/XTMF2/ModelSystemConstruct/Parameters/BasicParameter.cs
+++ b/src/XTMF2/ModelSystemConstruct/Parameters/BasicParameter.cs
@@ -67,6 +67,23 @@ internal class BasicParameter : ParameterExpression
         return false;
     }
 
+    public override bool GetValueAtEditingTime(Type outputType, 
+        [NotNullWhen(true)] out object? convertedValue,
+        [NotNullWhen(false)] out string? errorString)
+    {
+        string? error = null;
+        var (success, value) = ArbitraryParameterParser.ArbitraryParameterParse(outputType, _value, ref error);
+        if (success)
+        {
+            convertedValue = value!;
+            errorString = null;
+            return true;
+        }
+        convertedValue = null;
+        errorString = error ?? $"The parameter value {_value} is not compatible with the output type {outputType}.";
+        return false;
+    }
+
     public override Type Type => _type;
 
     internal override void Save(Utf8JsonWriter writer)

--- a/src/XTMF2/ModelSystemConstruct/Parameters/Compiler/BinaryOperators/AddOperator.cs
+++ b/src/XTMF2/ModelSystemConstruct/Parameters/Compiler/BinaryOperators/AddOperator.cs
@@ -29,12 +29,12 @@ internal sealed class AddOperator : Expression
     /// <summary>
     /// The left hand side expression
     /// </summary>
-    private readonly Expression _lhs;
+    internal readonly Expression _lhs;
 
     /// <summary>
     /// The right hand side expression.
     /// </summary>
-    private readonly Expression _rhs;
+    internal readonly Expression _rhs;
 
     /// <summary>
     /// Create a new add operation.

--- a/src/XTMF2/ModelSystemConstruct/Parameters/ScriptedParameter.cs
+++ b/src/XTMF2/ModelSystemConstruct/Parameters/ScriptedParameter.cs
@@ -51,6 +51,28 @@ internal class ScriptedParameter : ParameterExpression
         return null;
     }
 
+    public override bool GetValueAtEditingTime(Type outputType, 
+        [NotNullWhen(true)] out object? convertedValue,
+        [NotNullWhen(false)] out string? errorString)
+    {
+        string? error = null;
+        if(_expression.Type != outputType)
+        {
+            errorString = ThrowInvalidTypes(outputType, _expression.Type);
+            convertedValue = null;
+            return false;
+        }
+        if (ParameterCompiler.Evaluate(null!, _expression, out var ret, ref error))
+        {
+            convertedValue = ret;
+            errorString = null;
+            return true;
+        }
+        convertedValue = null;
+        errorString = error;
+        return false;
+    }
+
     public override bool IsCompatible(Type type, [NotNullWhen(false)] ref string? errorString)
     {
         return type.IsAssignableFrom(_expression.Type);

--- a/src/XTMF2/ModelSystemConstruct/SingleLink.cs
+++ b/src/XTMF2/ModelSystemConstruct/SingleLink.cs
@@ -24,160 +24,166 @@ using XTMF2.Editing;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
-namespace XTMF2.ModelSystemConstruct
+namespace XTMF2.ModelSystemConstruct;
+
+public sealed class SingleLink : Link
 {
-    public sealed class SingleLink : Link
+    public Node Destination { get; private set; }
+    public bool DestinationHidden { get; private set; }
+
+    public SingleLink(Node origin, NodeHook hook, Node destination, bool disabled, bool orthogonal = false,
+        bool destinationHidden = false, Guid id = default)
+        : base(origin, hook, disabled, orthogonal, id)
     {
-        public Node Destination { get; private set; }
-        public bool DestinationHidden { get; private set; }
+        Destination = destination;
+        DestinationHidden = destinationHidden;
+    }
 
-        public SingleLink(Node origin, NodeHook hook, Node destination, bool disabled, bool orthogonal = false,
-            bool destinationHidden = false, Guid id = default)
-            : base(origin, hook, disabled, orthogonal, id)
+    internal bool SetDestination(Node destination, out CommandError? error)
+    {
+        Destination = destination;
+        Notify(nameof(Destination));
+        error = null;
+        return true;
+    }
+
+    internal override void Save(Dictionary<Node, int> moduleDictionary, Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject();
+        writer.WriteString(IdProperty, Id);
+        writer.WriteNumber(OriginProperty, moduleDictionary[Origin!]);
+        writer.WriteString(HookProperty, OriginHook.Name);
+        writer.WriteNumber(DestinationProperty, moduleDictionary[Destination!]);
+        if (IsDisabled)
         {
-            Destination = destination;
-            DestinationHidden = destinationHidden;
+            writer.WriteBoolean(DisabledProperty, true);
+        }
+        if (IsOrthogonal)
+        {
+            writer.WriteBoolean(OrthogonalProperty, true);
+        }
+        if (DestinationHidden)
+        {
+            writer.WriteBoolean(HiddenDestinationsProperty, true);
+        }
+        writer.WriteEndObject();
+    }
+
+    public override int DestinationCount => 1;
+
+    public override bool IsDestinationHidden(int destinationIndex)
+        => destinationIndex == 0 && DestinationHidden;
+
+    internal override bool SetDestinationHidden(int destinationIndex, bool hidden, [NotNullWhen(false)] out CommandError? error)
+    {
+        if (destinationIndex != 0)
+        {
+            error = new CommandError("Destination index out of range for SingleLink.");
+            return false;
         }
 
-        internal bool SetDestination(Node destination, out CommandError? error)
+        DestinationHidden = hidden;
+        Notify(nameof(DestinationHidden));
+        error = null;
+        return true;
+    }
+
+    internal override bool SetAllDestinationsHidden(bool hidden, [NotNullWhen(false)] out CommandError? error)
+        => SetDestinationHidden(0, hidden, out error);
+
+    internal override bool Construct(ref string? error)
+    {
+        if (Origin.IsDisabled)
         {
-            Destination = destination;
-            Notify(nameof(Destination));
             error = null;
             return true;
         }
 
-        internal override void Save(Dictionary<Node, int> moduleDictionary, Utf8JsonWriter writer)
+        // FunctionParameter destinations are resolved transitively at runtime by
+        // FunctionInstance.ConstructRuntimeLink(); no static wiring is needed here.
+        if (Destination is FunctionParameter)
         {
-            writer.WriteStartObject();
-            writer.WriteString(IdProperty, Id);
-            writer.WriteNumber(OriginProperty, moduleDictionary[Origin!]);
-            writer.WriteString(HookProperty, OriginHook.Name);
-            writer.WriteNumber(DestinationProperty, moduleDictionary[Destination!]);
-            if (IsDisabled)
-            {
-                writer.WriteBoolean(DisabledProperty, true);
-            }
-            if (IsOrthogonal)
-            {
-                writer.WriteBoolean(OrthogonalProperty, true);
-            }
-            if (DestinationHidden)
-            {
-                writer.WriteBoolean(HiddenDestinationsProperty, true);
-            }
-            writer.WriteEndObject();
-        }
-
-        public override int DestinationCount => 1;
-
-        public override bool IsDestinationHidden(int destinationIndex)
-            => destinationIndex == 0 && DestinationHidden;
-
-        internal override bool SetDestinationHidden(int destinationIndex, bool hidden, [NotNullWhen(false)] out CommandError? error)
-        {
-            if (destinationIndex != 0)
-            {
-                error = new CommandError("Destination index out of range for SingleLink.");
-                return false;
-            }
-
-            DestinationHidden = hidden;
-            Notify(nameof(DestinationHidden));
             error = null;
             return true;
         }
 
-        internal override bool SetAllDestinationsHidden(bool hidden, [NotNullWhen(false)] out CommandError? error)
-            => SetDestinationHidden(0, hidden, out error);
-
-        internal override bool Construct(ref string? error)
+        // If the origin is a FunctionInstance wired through a FunctionParameterHook,
+        // record the parameter binding so FunctionInstance can route internal links
+        // to the actual external module at runtime.
+        if (Origin is FunctionInstance fiBinder && OriginHook is FunctionParameterHook fph)
         {
-            if (Origin.IsDisabled)
+            var resolvedFiDest = Destination is GhostNode gnFi
+                ? gnFi.ReferencedNode
+                : Destination!;
+            IModule? bindModule;
+            if (resolvedFiDest is FunctionInstance destFiBinder)
             {
-                error = null;
-                return true;
-            }
-
-            // FunctionParameter destinations are resolved transitively at runtime by
-            // FunctionInstance.ConstructRuntimeLink(); no static wiring is needed here.
-            if (Destination is FunctionParameter)
-            {
-                error = null;
-                return true;
-            }
-
-            // If the origin is a FunctionInstance wired through a FunctionParameterHook,
-            // record the parameter binding so FunctionInstance can route internal links
-            // to the actual external module at runtime.
-            if (Origin is FunctionInstance fiBinder && OriginHook is FunctionParameterHook fph)
-            {
-                var resolvedFiDest = Destination is GhostNode gnFi
-                    ? gnFi.ReferencedNode
-                    : Destination!;
-                IModule? bindModule;
-                if (resolvedFiDest is FunctionInstance destFiBinder)
-                {
-                    bindModule = destFiBinder.Template.EntryNode is not null
-                        ? destFiBinder.GetRuntimeModule(destFiBinder.Template.EntryNode)
-                        : null;
-                }
-                else
-                {
-                    bindModule = resolvedFiDest.Module;
-                }
-                fiBinder.BindParameter(fph.Parameter, bindModule);
-                error = null;
-                return true;
-            }
-
-            // Resolve ghost-node destinations to their real node.
-            var resolved = Destination is GhostNode gn ? gn.ReferencedNode : Destination!;
-
-            // Determine the effective destination node (for cardinality/disabled checks)
-            // and the actual IModule to wire (per-instance clone for FunctionInstances).
-            Node effectiveDest;
-            IModule? destModule;
-            bool destinationIsDisabled;
-            if (resolved is FunctionInstance fi)
-            {
-                effectiveDest = fi.Template.EntryNode ?? resolved;
-                destModule    = fi.Template.EntryNode is not null
-                    ? fi.GetRuntimeModule(fi.Template.EntryNode)
+                bindModule = destFiBinder.Template.EntryNode is not null
+                    ? destFiBinder.GetRuntimeModule(destFiBinder.Template.EntryNode)
                     : null;
-                destinationIsDisabled = fi.IsDisabled || effectiveDest.IsDisabled;
             }
             else
             {
-                effectiveDest = resolved;
-                destModule    = resolved.Module;
-                destinationIsDisabled = effectiveDest.IsDisabled;
+                bindModule = resolvedFiDest.Module;
             }
-
-            // if not optional
-            if (OriginHook!.Cardinality == HookCardinality.Single)
-            {
-                if (destinationIsDisabled)
-                {
-                    error = "A link destined for a disabled module was not optional.";
-                    return false;
-                }
-                if (IsDisabled)
-                {
-                    error = "A non optional link is disabled!";
-                    return false;
-                }
-            }
-            if (!IsDisabled && !destinationIsDisabled && destModule is not null)
-            {
-                OriginHook.Install(Origin!.Module!, destModule, 0);
-            }
+            fiBinder.BindParameter(fph.Parameter, bindModule);
+            error = null;
             return true;
         }
 
-        internal override bool HasDestination(Node destNode)
+        // Resolve ghost-node destinations to their real node.
+        var resolved = Destination is GhostNode gn ? gn.ReferencedNode : Destination!;
+
+        // Determine the effective destination node (for cardinality/disabled checks)
+        // and the actual IModule to wire (per-instance clone for FunctionInstances).
+        Node effectiveDest;
+        IModule? destModule;
+        bool destinationIsDisabled;
+        if (resolved is FunctionInstance fi)
         {
-            return Destination == destNode;
+            effectiveDest = fi.Template.EntryNode ?? resolved;
+            destModule    = fi.Template.EntryNode is not null
+                ? fi.GetRuntimeModule(fi.Template.EntryNode)
+                : null;
+            destinationIsDisabled = fi.IsDisabled || effectiveDest.IsDisabled;
         }
+        else
+        {
+            effectiveDest = resolved;
+            destModule    = resolved.Module;
+            destinationIsDisabled = effectiveDest.IsDisabled;
+        }
+
+        // if not optional
+        if (OriginHook!.Cardinality == HookCardinality.Single)
+        {
+            if (destinationIsDisabled)
+            {
+                error = "A link destined for a disabled module was not optional.";
+                return false;
+            }
+            if (IsDisabled)
+            {
+                error = "A non optional link is disabled!";
+                return false;
+            }
+        }
+        if (!IsDisabled && !destinationIsDisabled && destModule is not null)
+        {
+            OriginHook.Install(Origin!.Module!, destModule, 0);
+        }
+        return true;
+    }
+
+    internal override bool HasDestination(Node destNode)
+    {
+        return Destination == destNode;
+    }
+
+    override internal bool TryGetFirstDestination([NotNullWhen(true)] out object? dest)
+    {
+        dest = Destination;
+        return dest is not null;
     }
 }
+

--- a/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
+++ b/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
@@ -71,6 +71,132 @@ public class ModelSystemCanvasHeadlessTests
     }
 
     [TestMethod]
+    public void ModelSystemCanvas_BuildUpdatedFilePathValue_RewritesRightHandStringLiteral()
+    {
+        var method = typeof(ModelSystemCanvas).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .Single(m => m.Name == "BuildUpdatedFilePathValue" && m.GetParameters().Length == 3);
+        Assert.IsNotNull(method, "BuildUpdatedFilePathValue helper should exist.");
+
+        var updated = (string)method!.Invoke(null, new object?[]
+        {
+            "\"C:/old/file.txt\" + \"suffix.txt\"",
+            "/tmp/new-file.txt",
+            null
+        })!;
+
+        Assert.AreEqual("\"C:/old/file.txt\" + \"/tmp/new-file.txt\"", updated);
+    }
+
+    [TestMethod]
+    public void ModelSystemCanvas_ResolveFilePathTargetNode_TargetsParameterNodeFromHook()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(ModelSystemCanvas_ResolveFilePathTargetNode_TargetsParameterNodeFromHook),
+            (user, projectSession, msSession) =>
+            {
+                var boundary = msSession.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(msSession.AddNode(
+                    user,
+                    boundary,
+                    "OpenReadStreamModule",
+                    typeof(XTMF2.RuntimeModules.OpenReadStreamFromFile),
+                    new Rectangle(20, 20, 160, 60),
+                    out var sourceNode,
+                    out var error), error?.Message);
+                Assert.IsNotNull(sourceNode);
+
+                Assert.IsTrue(msSession.AddNode(
+                    user,
+                    boundary,
+                    "FilePathParameter",
+                    typeof(XTMF2.RuntimeModules.BasicParameter<string>),
+                    new Rectangle(220, 20, 160, 60),
+                    out var parameterNode,
+                    out var error2), error2?.Message);
+                Assert.IsNotNull(parameterNode);
+
+                var filePathHook = sourceNode!.Hooks.First(h => h.Name == "File Path");
+                Assert.IsTrue(msSession.AddLink(user, sourceNode, filePathHook, parameterNode!, out _, out var linkError), linkError?.Message);
+
+                using var vm = new ModelSystemEditorViewModel(msSession, user, runController: null);
+                var sourceVm = vm.Nodes.FirstOrDefault(n => ReferenceEquals(n.UnderlyingNode, sourceNode));
+                Assert.IsNotNull(sourceVm);
+
+                var canvas = new ModelSystemCanvas();
+                var method = typeof(ModelSystemCanvas).GetMethod(
+                    "ResolveFilePathTargetNode",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.IsNotNull(method);
+
+                var result = (Node?)method!.Invoke(canvas, new object[] { sourceVm! });
+                Assert.AreSame(parameterNode, result);
+            });
+    }
+
+    [TestMethod]
+    public void ModelSystemCanvas_BuildUpdatedFilePathValue_PreservesDirectoryVariableWhenDirectoryMatches()
+    {
+        var method = typeof(ModelSystemCanvas).GetMethod(
+            "BuildUpdatedFilePathValue",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(string), typeof(string), typeof(string)],
+            modifiers: null);
+        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
+
+        var updated = (string)method!.Invoke(null, new object[]
+        {
+            "\"/tmp\" + \"localFilePath.csv\"",
+            "/tmp/newFile.csv",
+            "/tmp/localFilePath.csv"
+        })!;
+
+        Assert.AreEqual("\"/tmp\" + \"newFile.csv\"", updated);
+    }
+
+    [TestMethod]
+    public void ModelSystemCanvas_BuildUpdatedFilePathValue_PreservesSharedPrefixForSubdirectorySelection()
+    {
+        var method = typeof(ModelSystemCanvas).GetMethod(
+            "BuildUpdatedFilePathValue",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(string), typeof(string), typeof(string)],
+            modifiers: null);
+        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
+
+        var updated = (string)method!.Invoke(null, new object[]
+        {
+            "\"/tmp/shared\" + \"oldFile.csv\"",
+            "/tmp/shared/sub/newFile.csv",
+            "/tmp/shared/oldFile.csv"
+        })!;
+
+        Assert.AreEqual("\"/tmp/shared\" + \"sub/newFile.csv\"", updated);
+    }
+
+    [TestMethod]
+    public void ModelSystemCanvas_BuildUpdatedFilePathValue_UsesFullValueWhenDirectoryDoesNotMatchSelection()
+    {
+        var method = typeof(ModelSystemCanvas).GetMethod(
+            "BuildUpdatedFilePathValue",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(string), typeof(string), typeof(string)],
+            modifiers: null);
+        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
+
+        var updated = (string)method!.Invoke(null, new object[]
+        {
+            "InputDirectory + \"oldFile.csv\"",
+            "/tmp/other/newFile.csv",
+            "/tmp/shared/oldFile.csv"
+        })!;
+
+        Assert.AreEqual("\"/tmp/other/newFile.csv\"", updated);
+    }
+
+    [TestMethod]
     public void ModelSystemCanvas_NameEdit_IsCanceledWhenEditedNodeIsDeleted()
     {
         TestGuiHelper.RunInModelSystemContext(

--- a/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
+++ b/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
@@ -26,6 +26,7 @@ using XTMF2.GUI.ViewModels;
 using XTMF2.ModelSystemConstruct;
 using System.Linq;
 using System.Reflection;
+using System;
 
 namespace XTMF2.GUI.Tests.Headless;
 
@@ -137,7 +138,8 @@ public class ModelSystemCanvasHeadlessTests
                 using var vm = new ModelSystemEditorViewModel(msSession, user, runController: null);
                 var nodeVm = vm.Nodes.FirstOrDefault(n => ReferenceEquals(n.UnderlyingNode, parameterNode));
                 Assert.IsNotNull(nodeVm);
-
+                // Set the UX to invarient culture to ensure the context menu is consistent across locales.
+                System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
                 Session.Dispatch(() =>
                 {
                     var canvas = new ModelSystemCanvas { DataContext = vm };
@@ -160,7 +162,8 @@ public class ModelSystemCanvasHeadlessTests
                         .ToArray();
 
                     CollectionAssert.Contains(fileItemHeaders, "Open");
-                    CollectionAssert.Contains(fileItemHeaders, "Set…");
+                    CollectionAssert.Contains(fileItemHeaders, "Set File…");
+                    CollectionAssert.Contains(fileItemHeaders, "Set Directory…");
                 }, System.Threading.CancellationToken.None).GetAwaiter().GetResult();
             });
     }

--- a/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
+++ b/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
@@ -117,6 +117,55 @@ public class ModelSystemCanvasHeadlessTests
     }
 
     [TestMethod]
+    public void ModelSystemCanvas_ContextMenu_ShowsFileSubmenuForStringFilePathNodes()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(ModelSystemCanvas_ContextMenu_ShowsFileSubmenuForStringFilePathNodes),
+            (user, projectSession, msSession) =>
+            {
+                var boundary = msSession.ModelSystem.GlobalBoundary;
+                Assert.IsTrue(msSession.AddNode(
+                    user,
+                    boundary,
+                    "FilePathParameter",
+                    typeof(XTMF2.RuntimeModules.BasicParameter<string>),
+                    new Rectangle(20, 20, 160, 60),
+                    out var parameterNode,
+                    out var error), error?.Message);
+                Assert.IsNotNull(parameterNode);
+
+                using var vm = new ModelSystemEditorViewModel(msSession, user, runController: null);
+                var nodeVm = vm.Nodes.FirstOrDefault(n => ReferenceEquals(n.UnderlyingNode, parameterNode));
+                Assert.IsNotNull(nodeVm);
+
+                Session.Dispatch(() =>
+                {
+                    var canvas = new ModelSystemCanvas { DataContext = vm };
+                    var showMenu = typeof(ModelSystemCanvas).GetMethod(
+                        "ShowContextMenu",
+                        BindingFlags.Instance | BindingFlags.NonPublic);
+                    Assert.IsNotNull(showMenu);
+
+                    showMenu!.Invoke(canvas, new object?[] { nodeVm!, null });
+
+                    var menu = canvas.ContextMenu;
+                    Assert.IsNotNull(menu);
+
+                    var fileMenu = menu!.Items.OfType<MenuItem>().FirstOrDefault(item =>
+                        string.Equals(item.Header?.ToString(), "File", System.StringComparison.Ordinal));
+                    Assert.IsNotNull(fileMenu);
+
+                    var fileItemHeaders = fileMenu!.Items.OfType<MenuItem>()
+                        .Select(item => item.Header?.ToString())
+                        .ToArray();
+
+                    CollectionAssert.Contains(fileItemHeaders, "Open");
+                    CollectionAssert.Contains(fileItemHeaders, "Set…");
+                }, System.Threading.CancellationToken.None).GetAwaiter().GetResult();
+            });
+    }
+
+    [TestMethod]
     public void ModelSystemCanvas_NameEdit_IsCanceledWhenEditedNodeIsDeleted()
     {
         TestGuiHelper.RunInModelSystemContext(

--- a/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
+++ b/tests/XTMF2.GUI.Tests/Headless/ModelSystemCanvasHeadlessTests.cs
@@ -71,23 +71,6 @@ public class ModelSystemCanvasHeadlessTests
     }
 
     [TestMethod]
-    public void ModelSystemCanvas_BuildUpdatedFilePathValue_RewritesRightHandStringLiteral()
-    {
-        var method = typeof(ModelSystemCanvas).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Single(m => m.Name == "BuildUpdatedFilePathValue" && m.GetParameters().Length == 3);
-        Assert.IsNotNull(method, "BuildUpdatedFilePathValue helper should exist.");
-
-        var updated = (string)method!.Invoke(null, new object?[]
-        {
-            "\"C:/old/file.txt\" + \"suffix.txt\"",
-            "/tmp/new-file.txt",
-            null
-        })!;
-
-        Assert.AreEqual("\"C:/old/file.txt\" + \"/tmp/new-file.txt\"", updated);
-    }
-
-    [TestMethod]
     public void ModelSystemCanvas_ResolveFilePathTargetNode_TargetsParameterNodeFromHook()
     {
         TestGuiHelper.RunInModelSystemContext(
@@ -131,69 +114,6 @@ public class ModelSystemCanvasHeadlessTests
                 var result = (Node?)method!.Invoke(canvas, new object[] { sourceVm! });
                 Assert.AreSame(parameterNode, result);
             });
-    }
-
-    [TestMethod]
-    public void ModelSystemCanvas_BuildUpdatedFilePathValue_PreservesDirectoryVariableWhenDirectoryMatches()
-    {
-        var method = typeof(ModelSystemCanvas).GetMethod(
-            "BuildUpdatedFilePathValue",
-            BindingFlags.Static | BindingFlags.NonPublic,
-            binder: null,
-            types: [typeof(string), typeof(string), typeof(string)],
-            modifiers: null);
-        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
-
-        var updated = (string)method!.Invoke(null, new object[]
-        {
-            "\"/tmp\" + \"localFilePath.csv\"",
-            "/tmp/newFile.csv",
-            "/tmp/localFilePath.csv"
-        })!;
-
-        Assert.AreEqual("\"/tmp\" + \"newFile.csv\"", updated);
-    }
-
-    [TestMethod]
-    public void ModelSystemCanvas_BuildUpdatedFilePathValue_PreservesSharedPrefixForSubdirectorySelection()
-    {
-        var method = typeof(ModelSystemCanvas).GetMethod(
-            "BuildUpdatedFilePathValue",
-            BindingFlags.Static | BindingFlags.NonPublic,
-            binder: null,
-            types: [typeof(string), typeof(string), typeof(string)],
-            modifiers: null);
-        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
-
-        var updated = (string)method!.Invoke(null, new object[]
-        {
-            "\"/tmp/shared\" + \"oldFile.csv\"",
-            "/tmp/shared/sub/newFile.csv",
-            "/tmp/shared/oldFile.csv"
-        })!;
-
-        Assert.AreEqual("\"/tmp/shared\" + \"sub/newFile.csv\"", updated);
-    }
-
-    [TestMethod]
-    public void ModelSystemCanvas_BuildUpdatedFilePathValue_UsesFullValueWhenDirectoryDoesNotMatchSelection()
-    {
-        var method = typeof(ModelSystemCanvas).GetMethod(
-            "BuildUpdatedFilePathValue",
-            BindingFlags.Static | BindingFlags.NonPublic,
-            binder: null,
-            types: [typeof(string), typeof(string), typeof(string)],
-            modifiers: null);
-        Assert.IsNotNull(method, "BuildUpdatedFilePathValue overload for scripted expressions should exist.");
-
-        var updated = (string)method!.Invoke(null, new object[]
-        {
-            "InputDirectory + \"oldFile.csv\"",
-            "/tmp/other/newFile.csv",
-            "/tmp/shared/oldFile.csv"
-        })!;
-
-        Assert.AreEqual("\"/tmp/other/newFile.csv\"", updated);
     }
 
     [TestMethod]

--- a/tests/XTMF2.GUI.Tests/ViewModels/ModelSystemEditorViewModelClipboardTests.cs
+++ b/tests/XTMF2.GUI.Tests/ViewModels/ModelSystemEditorViewModelClipboardTests.cs
@@ -1,0 +1,231 @@
+/*
+    Copyright 2026 University of Toronto
+
+    This file is part of XTMF2.
+
+    XTMF2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF2.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using XTMF2.GUI.ViewModels;
+using XTMF2.ModelSystemConstruct;
+
+namespace XTMF2.GUI.Tests.ViewModels;
+
+[TestClass]
+public class ModelSystemEditorViewModelClipboardTests
+{
+    [TestMethod]
+    public void ClipboardSerializer_CommentBlock_UsesBodyField()
+    {
+        var payload = new CanvasClipboardPayload(
+            Source: "XTMF2Canvas",
+            Version: 1,
+            Elements:
+            [
+                new CanvasElementDto(
+                    Kind: CanvasElementKind.CommentBlock,
+                    X: 1f,
+                    Y: 2f,
+                    W: 3f,
+                    H: 4f,
+                    Name: null,
+                    CommentBody: "Body text",
+                    CommentHeader: "Header")
+            ]);
+
+        var json = CanvasClipboardSerializer.Serialize(payload);
+        Assert.IsTrue(json.Contains("\"body\":\"Body text\"", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(json, "\"name\":", System.StringComparison.Ordinal);
+
+        var roundTrip = CanvasClipboardSerializer.TryDeserialize(json);
+        Assert.IsNotNull(roundTrip);
+        Assert.HasCount(1, roundTrip.Elements);
+        Assert.AreEqual(CanvasElementKind.CommentBlock, roundTrip.Elements[0].Kind);
+        Assert.AreEqual("Body text", roundTrip.Elements[0].CommentBody);
+        Assert.AreEqual("Header", roundTrip.Elements[0].CommentHeader);
+        Assert.IsNull(roundTrip.Elements[0].Name);
+    }
+
+    [TestMethod]
+    public void PasteElementsAsync_CommentBlock_RestoresHeader()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(PasteElementsAsync_CommentBlock_RestoresHeader),
+            (user, _, msSession) =>
+            {
+                using var vmEditor = new ModelSystemEditorViewModel(msSession, user, runController: null);
+
+                var payload = new CanvasClipboardPayload(
+                    Source: "XTMF2Canvas",
+                    Version: 1,
+                    Elements:
+                    [
+                        new CanvasElementDto(
+                            Kind: CanvasElementKind.CommentBlock,
+                            X: 10f,
+                            Y: 15f,
+                            W: 200f,
+                            H: 80f,
+                            Name: null,
+                            CommentBody: "Body text",
+                            CommentHeader: "Copied Header")
+                    ]);
+
+                vmEditor.PasteElementsAsync(payload, anchorX: 0, anchorY: 0)
+                    .GetAwaiter().GetResult();
+
+                var comments = msSession.ModelSystem.GlobalBoundary.CommentBlocks;
+                Assert.HasCount(1, comments);
+                Assert.AreEqual("Body text", comments[0].Comment);
+                Assert.AreEqual("Copied Header", comments[0].Header);
+            });
+    }
+
+    [TestMethod]
+    public void PasteElementsAsync_CommentBlock_AllowsEmptyBody()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(PasteElementsAsync_CommentBlock_AllowsEmptyBody),
+            (user, _, msSession) =>
+            {
+                using var vmEditor = new ModelSystemEditorViewModel(msSession, user, runController: null);
+
+                var payload = new CanvasClipboardPayload(
+                    Source: "XTMF2Canvas",
+                    Version: 1,
+                    Elements:
+                    [
+                        new CanvasElementDto(
+                            Kind: CanvasElementKind.CommentBlock,
+                            X: 10f,
+                            Y: 15f,
+                            W: 200f,
+                            H: 80f,
+                            Name: null,
+                            CommentBody: string.Empty,
+                            CommentHeader: "Header Only")
+                    ]);
+
+                vmEditor.PasteElementsAsync(payload, anchorX: 0, anchorY: 0)
+                    .GetAwaiter().GetResult();
+
+                var comments = msSession.ModelSystem.GlobalBoundary.CommentBlocks;
+                Assert.HasCount(1, comments);
+                Assert.AreEqual(string.Empty, comments[0].Comment);
+                Assert.AreEqual("Header Only", comments[0].Header);
+            });
+    }
+
+    [TestMethod]
+    public void PasteElementsAsync_CommentBlock_LegacyNameFallbackStillWorks()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(PasteElementsAsync_CommentBlock_LegacyNameFallbackStillWorks),
+            (user, _, msSession) =>
+            {
+                using var vmEditor = new ModelSystemEditorViewModel(msSession, user, runController: null);
+
+                var payload = new CanvasClipboardPayload(
+                    Source: "XTMF2Canvas",
+                    Version: 1,
+                    Elements:
+                    [
+                        new CanvasElementDto(
+                            Kind: CanvasElementKind.CommentBlock,
+                            X: 10f,
+                            Y: 15f,
+                            W: 200f,
+                            H: 80f,
+                            Name: "Legacy body text",
+                            CommentHeader: "Legacy Header")
+                    ]);
+
+                vmEditor.PasteElementsAsync(payload, anchorX: 0, anchorY: 0)
+                    .GetAwaiter().GetResult();
+
+                var comments = msSession.ModelSystem.GlobalBoundary.CommentBlocks;
+                Assert.HasCount(1, comments);
+                Assert.AreEqual("Legacy body text", comments[0].Comment);
+                Assert.AreEqual("Legacy Header", comments[0].Header);
+            });
+    }
+
+    [TestMethod]
+    public void PasteElementsAsync_CommentBlock_WorksInInnerBoundary()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(PasteElementsAsync_CommentBlock_WorksInInnerBoundary),
+            (user, _, msSession) =>
+            {
+                Assert.IsTrue(msSession.AddBoundary(user, msSession.ModelSystem.GlobalBoundary, "Inner",
+                    out var inner, out var error), error?.Message);
+                Assert.IsNotNull(inner);
+
+                using var vmEditor = new ModelSystemEditorViewModel(msSession, user, runController: null);
+                vmEditor.SwitchToBoundary(inner!);
+
+                var payload = new CanvasClipboardPayload(
+                    Source: "XTMF2Canvas",
+                    Version: 1,
+                    Elements:
+                    [
+                        new CanvasElementDto(
+                            Kind: CanvasElementKind.CommentBlock,
+                            X: 10f,
+                            Y: 15f,
+                            W: 200f,
+                            H: 80f,
+                            Name: null,
+                            CommentBody: "Inner body",
+                            CommentHeader: "Inner header")
+                    ]);
+
+                vmEditor.PasteElementsAsync(payload, anchorX: 0, anchorY: 0)
+                    .GetAwaiter().GetResult();
+
+                Assert.HasCount(1, inner.CommentBlocks);
+                Assert.AreEqual("Inner body", inner.CommentBlocks[0].Comment);
+                Assert.AreEqual("Inner header", inner.CommentBlocks[0].Header);
+                Assert.HasCount(1, vmEditor.CommentBlocks);
+                Assert.AreEqual("Inner body", vmEditor.CommentBlocks[0].Name);
+            });
+    }
+
+    [TestMethod]
+    public void AddCommentBlock_AfterBoundarySwitch_DoesNotDuplicateViewModelEntries()
+    {
+        TestGuiHelper.RunInModelSystemContext(
+            nameof(AddCommentBlock_AfterBoundarySwitch_DoesNotDuplicateViewModelEntries),
+            (user, _, msSession) =>
+            {
+                Assert.IsTrue(msSession.AddBoundary(user, msSession.ModelSystem.GlobalBoundary, "Inner",
+                    out var inner, out var error), error?.Message);
+                Assert.IsNotNull(inner);
+
+                using var vmEditor = new ModelSystemEditorViewModel(msSession, user, runController: null);
+
+                vmEditor.SwitchToBoundary(inner!);
+                vmEditor.SwitchToBoundary(msSession.ModelSystem.GlobalBoundary);
+                vmEditor.SwitchToBoundary(inner!);
+
+                Assert.IsTrue(msSession.AddCommentBlock(user, inner!, "After switch", new Rectangle(20, 20, 200, 80),
+                    out var block, out error), error?.Message);
+                Assert.IsNotNull(block);
+
+                Assert.HasCount(1, inner!.CommentBlocks);
+                Assert.HasCount(1, vmEditor.CommentBlocks);
+                Assert.AreEqual("After switch", vmEditor.CommentBlocks[0].Name);
+            });
+    }
+}

--- a/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestCommentBlock.cs
@@ -45,6 +45,23 @@ namespace XTMF2.UnitTests.Editing
         }
 
         [TestMethod]
+        public void TestCreatingEmptyCommentBlock()
+        {
+            TestHelper.RunInModelSystemContext("TestCreatingEmptyCommentBlock", (user, pSession, mSession) =>
+            {
+                CommandError error = null;
+                var ms = mSession.ModelSystem;
+                var location = new Rectangle(100, 100);
+                var comBlocks = ms.GlobalBoundary.CommentBlocks;
+                Assert.IsEmpty(comBlocks);
+                Assert.IsTrue(mSession.AddCommentBlock(user, ms.GlobalBoundary, string.Empty, location, out CommentBlock block, out error), error?.Message);
+                Assert.HasCount(1, comBlocks);
+                Assert.AreEqual(string.Empty, comBlocks[0].Comment);
+                Assert.AreEqual(location, comBlocks[0].Location);
+            });
+        }
+
+        [TestMethod]
         public void TestCreatingCommentBlockWithBadUser()
         {
             TestHelper.RunInModelSystemContext("TestCreatingCommentBlockWithBadUser", (user, unauthorizedUser, pSession, mSession) =>
@@ -196,6 +213,31 @@ namespace XTMF2.UnitTests.Editing
                 Assert.AreEqual(comment, block.Comment, "The comment block's text was not undone!");
                 Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
                 Assert.AreEqual(newComment, block.Comment);
+            });
+        }
+
+        [TestMethod]
+        public void TestChangingCommentBlockTextToEmpty()
+        {
+            TestHelper.RunInModelSystemContext("TestChangingCommentBlockTextToEmpty", (user, pSession, msSession) =>
+            {
+                CommandError error = null;
+                var ms = msSession.ModelSystem;
+                var comment = "My Comment";
+                var location = new Rectangle(100, 100);
+                var comBlocks = ms.GlobalBoundary.CommentBlocks;
+                Assert.IsEmpty(comBlocks);
+                Assert.IsTrue(msSession.AddCommentBlock(user, ms.GlobalBoundary, comment, location, out CommentBlock block, out error), error?.Message);
+                Assert.HasCount(1, comBlocks);
+
+                Assert.IsTrue(msSession.SetCommentBlockText(user, block, string.Empty, out error), error?.Message);
+                Assert.AreEqual(string.Empty, block.Comment, "The comment block text should allow empty values.");
+
+                Assert.IsTrue(msSession.Undo(user, out error), error?.Message);
+                Assert.AreEqual(comment, block.Comment, "Undo should restore the original comment text.");
+
+                Assert.IsTrue(msSession.Redo(user, out error), error?.Message);
+                Assert.AreEqual(string.Empty, block.Comment, "Redo should reapply the empty comment text.");
             });
         }
 

--- a/tests/XTMF2.UnitTests/Editing/TestEditingParameterExpressions.cs
+++ b/tests/XTMF2.UnitTests/Editing/TestEditingParameterExpressions.cs
@@ -135,5 +135,23 @@ public class TestEditingParameterExpressions
             Assert.AreEqual("Hello World3", childNode.ParameterValue.GetValue(null, typeof(string), ref errorStr));
         });
     }
+
+    [TestMethod]
+    public void EvaluateParameterExpression_ReturnsScriptedValue()
+    {
+        TestHelper.RunInModelSystemContext("EvaluateParameterExpression_ReturnsScriptedValue", (user, pSession, mSession) =>
+        {
+            CommandError error = null;
+            var ms = mSession.ModelSystem;
+            Assert.IsTrue(mSession.AddNodeGenerateParameters(user, ms.GlobalBoundary, "Test",
+                typeof(SimpleParameterModule), Rectangle.Hidden, out var node, out var children, out error), error?.Message);
+            Assert.IsNotNull(children);
+            var childNode = children.FirstOrDefault(n => n.Name == "Real Function");
+            Assert.IsNotNull(childNode);
+            Assert.IsTrue(mSession.SetParameterExpression(user, childNode, "\"Hello World\" + (1 + 2)", out error), error?.Message);
+            Assert.IsTrue(mSession.EvaluateParameterExpression(childNode, out object value), "Expression should evaluate.");
+            Assert.AreEqual("Hello World3", value);
+        });
+    }
 }
 


### PR DESCRIPTION
Fixes the rendering of the comment blocks after being pasted, includes the headers of the comment blocks in the copy, and fixes the case where the body of the comment block is empty.
